### PR TITLE
Remove worker id from metric labels

### DIFF
--- a/orchestrator/metrics.js
+++ b/orchestrator/metrics.js
@@ -40,13 +40,13 @@ const gaugeWorkers = new client.Gauge({
 const workerLoadCPUStats = new client.Gauge({
     name : 'worker_load_cpu',
     help : 'Worker Load - CPU usage',
-    labelNames: ['worker_id', 'worker_name'],
+    labelNames: ['worker_name'],
 })
 
 const workerLoadTasksStats = new client.Gauge({
     name : 'worker_load_tasks',
     help : 'Worker Load - Tasks Count',
-    labelNames: ['worker_id', 'worker_name'],
+    labelNames: ['worker_name'],
 })
 
 module.exports = {
@@ -58,8 +58,8 @@ module.exports = {
 
     setActiveWorkers : (amount) => { gaugeWorkers.set(amount) },
     setActiveJobPosters : (amount) => { gaugeJobPosters.set(amount) },
-    setWorkerLoadCPU : (workerId, workerName, value) => { workerLoadCPUStats.labels(workerId, workerName).set(value) },
-    setWorkerLoadTasks : (workerId, workerName, value) => { workerLoadTasksStats.labels(workerId, workerName).set(value) },
+    setWorkerLoadCPU : (workerName, value) => { workerLoadCPUStats.labels(workerName).set(value) },
+    setWorkerLoadTasks : (workerName, value) => { workerLoadTasksStats.labels(workerName).set(value) },
     
     injectMetricsRoute : (app) => {  
         app.get('/metrics', (req, res) => {

--- a/orchestrator/orchestrator.js
+++ b/orchestrator/orchestrator.js
@@ -40,8 +40,8 @@ class Worker {
 
     updateStats(stats) {
         this.stats = { cpu : parseFloat(stats.cpu), tasks: parseInt(stats.tasks)}
-        metrics.setWorkerLoadCPU(this.id, this.host, this.stats.cpu)
-        metrics.setWorkerLoadTasks(this.id, this.host, this.stats.tasks)
+        metrics.setWorkerLoadCPU(this.host, this.stats.cpu)
+        metrics.setWorkerLoadTasks(this.host, this.stats.tasks)
     }
 }
 


### PR DESCRIPTION
Removing the worker id from the metric, since it causes confusion when workers are restarted.
Also, values with high cardinality should not be used as labels.