### PR TITLE
add option (off by default via being commented out) to use hardware accelerated decoding 

### DIFF
--- a/pms/transcoder.js
+++ b/pms/transcoder.js
@@ -28,6 +28,9 @@ if (TRANSCODE_OPERATING_MODE == 'local') {
     let newArgs = process.argv.slice(2).map((v) => {
         return v.replace('127.0.0.1:', `${PMS_IP}:`)
     })
+// inserting -hwaccel auto into transcoder arguments here
+// uncomment following line to evaluate change
+//	setValueOf(newArgs, '-hwaccel', 'auto')
 
     if (TRANSCODER_VERBOSE == '1') {
         console.log('Setting VERBOSE to ON')


### PR DESCRIPTION
add option (off by default via being commented out at line 33) to use hardware accelerated decoding by inserting "-hwaccel auto" into the newArg variable