### PR TITLE
Update base images on orchestrator

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,6 +1,8 @@
-FROM node:slim
+FROM node:lts-slim
 
 LABEL maintainer="pabloromeo"
+
+RUN apt-get update && apt-get install curl -y && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/orchestrator/Dockerfile.armhf
+++ b/orchestrator/Dockerfile.armhf
@@ -1,8 +1,10 @@
-FROM arm32v7/node:11-slim
+FROM arm32v7/node:lts-slim
 
 LABEL maintainer="pabloromeo"
 
 COPY qemu-arm-static /usr/bin/
+
+RUN apt-get update && apt-get install curl -y && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
Both archs use the same node version. Updated the arm arch to a newer base image.