### PR TITLE
Add hwaccel hint transcoder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ The image extends the [LinuxServer Plex](https://hub.docker.com/r/linuxserver/pl
 | :----: | --- |
 | `ORCHESTRATOR_URL` | The url where the orchestrator service can be reached (ex: http://plex-orchestrator:3500) |
 | `PMS_IP` | IP pointing at the Plex instance (can be the cluster IP) |
+| `TRANSCODE_FFMPEG_HWACCEL` | Allows a [hwaccel decoder](https://trac.ffmpeg.org/wiki/HWAccelIntro) to be passed to ffmpeg such as `nvdec` or `dvxa2` |
 | `TRANSCODE_OPERATING_MODE` | "local" => only local transcoding (no workers), "remote" => only remote workers transcoding, "both" (default) => Remote first, local if it fails |
 | `TRANSCODER_VERBOSE` | "0" (default) => info level, "1" => debug logging |
 

--- a/pms/app/transcoder.js
+++ b/pms/app/transcoder.js
@@ -37,16 +37,6 @@ if (TRANSCODE_OPERATING_MODE == 'local') {
         setValueOf(newArgs, '-loglevel_plex', 'verbose')    
     }
 
-    let environmentVariables = process.env
-    let workDir = process.cwd()
-
-    console.log(`Sending request to orchestrator on: ${ORCHESTRATOR_URL}`)
-    if (TRANSCODER_VERBOSE == '1') {
-        console.log(`cwd => ${JSON.stringify(workDir)}`)
-        console.log(`args => ${JSON.stringify(newArgs)}`)
-        console.log(`env => ${JSON.stringify(environmentVariables)}`)
-    }
-
     if (TRANSCODE_FFMPEG_HWACCEL != false) {
         console.log(`Setting hwaccel to ${TRANSCODE_FFMPEG_HWACCEL}`)
         let i = newArgs.indexOf('-hwaccel')
@@ -55,6 +45,16 @@ if (TRANSCODE_OPERATING_MODE == 'local') {
         } else {
             newArgs.unshift('-hwaccel', TRANSCODE_FFMPEG_HWACCEL)
         }
+    }
+
+    let environmentVariables = process.env
+    let workDir = process.cwd()
+
+    console.log(`Sending request to orchestrator on: ${ORCHESTRATOR_URL}`)
+    if (TRANSCODER_VERBOSE == '1') {
+        console.log(`cwd => ${JSON.stringify(workDir)}`)
+        console.log(`args => ${JSON.stringify(newArgs)}`)
+        console.log(`env => ${JSON.stringify(environmentVariables)}`)
     }
     
     jobPoster.postJob(ORCHESTRATOR_URL, 

--- a/pms/app/transcoder.js
+++ b/pms/app/transcoder.js
@@ -9,6 +9,8 @@ const TRANSCODER_VERBOSE = process.env.TRANSCODER_VERBOSE || '0'
 // remote
 // both
 const TRANSCODE_OPERATING_MODE = process.env.TRANSCODE_OPERATING_MODE || 'both'
+// hwaccel decoder: https://trac.ffmpeg.org/wiki/HWAccelIntro
+const TRANSCODE_FFMPEG_HWACCEL = process.env.TRANSCODE_FFMPEG_HWACCEL || false
 
 const { spawn } = require('child_process');
 var ON_DEATH = require('death')({debug: true})
@@ -43,6 +45,16 @@ if (TRANSCODE_OPERATING_MODE == 'local') {
         console.log(`cwd => ${JSON.stringify(workDir)}`)
         console.log(`args => ${JSON.stringify(newArgs)}`)
         console.log(`env => ${JSON.stringify(environmentVariables)}`)
+    }
+
+    if (TRANSCODE_FFMPEG_HWACCEL != false) {
+        console.log(`Setting hwaccel to ${TRANSCODE_FFMPEG_HWACCEL}`)
+        let i = newArgs.indexOf('-hwaccel')
+        if (i > 0) {
+            newArgs[i+1] = TRANSCODE_FFMPEG_HWACCEL
+        } else {
+            newArgs.unshift('-hwaccel', TRANSCODE_FFMPEG_HWACCEL)
+        }
     }
     
     jobPoster.postJob(ORCHESTRATOR_URL, 


### PR DESCRIPTION
This PR adds the ability to send a hwaccel decoder to a worker from the plex instance since plex itself may not detect hardware acceleration is available if the device is not shared with the plex container.

Plex logs:

```
Sep 30 11:54:30 krusty.thenursery.josc docker-compose[833961]: plex    | Calling external transcoder: /app/transcoder.js
Sep 30 11:54:31 krusty.thenursery.josc docker-compose[833961]: plex    | ON_DEATH: debug mode enabled for pid [1344]
Sep 30 11:54:31 krusty.thenursery.josc docker-compose[833961]: plex    | Setting VERBOSE to ON
Sep 30 11:54:31 krusty.thenursery.josc docker-compose[833961]: plex    | Setting hwaccel to nvdec
Sep 30 11:54:31 krusty.thenursery.josc docker-compose[833961]: plex    | Sending request to orchestrator on: http://10.11.12.13:3500
Sep 30 11:54:31 krusty.thenursery.josc docker-compose[833961]: plex    | cwd => "/tmp/transcode/Transcode/Sessions/plex-transcode-km0x12mdmrli76g5qgnn5fhh-5523e6ab-6b94-496d-b2d7-e0feb08d0ec1"
Sep 30 11:54:31 krusty.thenursery.josc docker-compose[833961]: plex    | args => ["-hwaccel","nvdec","-codec:#0x01","h264","-codec:#0x02","aac","-analyzeduration","20000000","-probesize","20000000","-i","/media/preroll/skotflix.mp4","-filter_complex","[0:#0x01]scale=w=1920:h=1080[0];[0]format=pix_fmts=yuv420p|nv12[1]","-map","[1]","-metadata:s:0","language=eng","-codec:0","libx264","-crf:0","16","-maxrate:0","324k","-bufsize:0","648k","-r:0","30","-preset:0","veryfast","-x264opts:0","subme=2:me_range=4:rc_lookahead=10:me=hex:8x8dct=1","-force_key_frames:0","expr:gte(t,n_forced*3)","-filter_complex","[0:#0x02] aresample=async=1:ocl='stereo':rematrix_maxval=0.000000dB:osr=48000[2]","-map","[2]","-metadata:s:1","language=eng","-codec:1","aac","-b:1","256k","-f","dash","-seg_duration","3","-dash_segment_type","mp4","-init_seg_name","init-stream$RepresentationID$.m4s","-media_seg_name","chunk-stream$RepresentationID$-$Number%05d$.m4s","-window_size","5","-delete_removed","false","-skip_to_segment","1","-time_delta","0.0625","-manifest_name","http://10.11.12.13:32400/video/:/transcode/session/km0x12mdmrli76g5qgnn5fhh/5523e6ab-6b94-496d-b2d7-e0feb08d0ec1/manifest?X-Plex-Http-Pipeline=infinite","-avoid_negative_ts","disabled","-map_metadata","-1","-map_chapters","-1","dash","-start_at_zero","-copyts","-vsync","cfr","-y","-nostats","-loglevel","verbose","-loglevel_plex","verbose","-progressurl","http://10.11.12.13:32400/video/:/transcode/session/km0x12mdmrli76g5qgnn5fhh/5523e6ab-6b94-496d-b2d7-e0feb08d0ec1/progress"]
Sep 30 11:54:31 krusty.thenursery.josc docker-compose[833961]: plex    | env => {"PUID":"65534","PLEX_ARCH":"amd64","HOSTNAME":"krusty.thenursery.josc","LANGUAGE":"en_US.UTF-8","TRANSCODE_FFMPEG_HWACCEL":"nvdec","TRANSCODE_OPERATING_MODE":"remote","ORCHESTRATOR_URL":"http://10.11.12.13:3500","PWD":"/tmp/transcode/Transcode/Sessions/plex-transcode-km0x12mdmrli76g5qgnn5fhh-5523e6ab-6b94-496d-b2d7-e0feb08d0ec1","PLEX_DOWNLOAD":"https://downloads.plex.tv/plex-media-server-new","PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS":"6","NVIDIA_DRIVER_CAPABILITIES":"compute,video,utility","PMS_IP":"10.11.12.13","TZ":"Australia/Melbourne","PLEX_MEDIA_SERVER_USER":"abc","HOME":"/root","LANG":"en_US.UTF-8","PGID":"65534","PLEX_CLAIM":"claim-rxWvbwVxSzbAs2vw3c8C","TERM":"xterm","PLEX_MEDIA_SERVER_INFO_VENDOR":"Docker","PLEX_MEDIA_SERVER_HOME":"/usr/lib/plexmediaserver","DOCKER_MODS":"ghcr.io/pabloromeo/clusterplex_dockermod","X_PLEX_TOKEN":"wAwDjSc-_3qwjua63Yap","PLEX_MEDIA_SERVER_INFO_MODEL":"x86_64","SHLVL":"0","LD_LIBRARY_PATH":"/usr/lib","PLEX_MEDIA_SERVER_INFO_PLATFORM_VERSION":"4.18.0-305.19.1.el8_4.x86_64","LIBVA_DRIVERS_PATH":"/usr/lib/plexmediaserver/lib/dri","PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR":"/config/Library/Application Support","CWD":"/","PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","VERSION":"docker","DEBIAN_FRONTEND":"noninteractive","PLEX_MEDIA_SERVER_INFO_DEVICE":"Docker Container (LinuxServer.io)","FFMPEG_EXTERNAL_LIBS":"/config/Library/Application\\ Support/Plex\\ Media\\ Server/Codecs/be22e26-4019-linux-x86_64/","TRANSCODER_VERBOSE":"1"}
Sep 30 11:54:31 krusty.thenursery.josc docker-compose[833961]: plex    | JobPoster connected, announcing
Sep 30 11:54:31 krusty.thenursery.josc docker-compose[833961]: plex    | Orchestrator requesting pending work
Sep 30 11:54:31 krusty.thenursery.josc docker-compose[833961]: plex    | Sending request to orchestrator on: http://10.11.12.13:3500
Sep 30 11:54:35 krusty.thenursery.josc docker-compose[833961]: plex    | Remote Transcoding was successful
```

Worker logs:

```
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7f9bf1a31f00] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7f9bf1a31f00] Successfully connected to 10.11.12.13 port 32400
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | ffmpeg version be22e26-4019 Copyright (c) 2000-2019 the FFmpeg developers
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |   built with Plex clang version 11.0.1 (https://plex.tv e0c29d5827bc4eaaa2ceb882cbeed224b0960173)
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |   configuration: --disable-static --enable-shared --disable-libx264 --disable-hwaccels --disable-protocol=concat --external-decoder=h264 --enable-debug --enable-muxers --enable-libxml2 --fatal-warnings --disable-gmp --disable-avdevice --disable-bzlib --disable-sdl2 --disable-decoders --disable-devices --disable-encoders --disable-ffprobe --disable-ffplay --disable-doc --disable-iconv --disable-lzma --disable-schannel --disable-linux-perf --disable-mediacodec --enable-eae --disable-protocol='udp,udplite' --arch=x86_64 --target-os=linux --strip=true --cc=x86_64-linux-musl-clang --pkg-config=/data/jenkins/conan_build/1111821918/plexconantool/plex-pkg-config --pkg-config-flags=--static --enable-cuda-llvm --enable-libdrm --enable-opencl --enable-cross-compile --ar=llvm-ar --nm=llvm-nm --ranlib=llvm-ranlib --extra-ldflags='-Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/lib -m64 -L/data/jenkins/conan_build/1111821918/conan/.conan/data/opus/1.2.1-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libvorbis/1.3.5-31/plex/stable/package/76eba14299c6c14bf4759b1da21aec07c9ca1a2f/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/ffnvcodec/9.0.18.2-9fdaf11-8/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/x264/161-1086f45-18/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/zvbi/0.2.35-51/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/rtmpdump/2.4-94/plex/stable/package/4168f635acadf1e81d21da6655c14c065dac9ac2/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libass/0.14.0-82/plex/stable/package/4fca6d6f1f27aa4bd2419e3401bbf5e7b4e99f27/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/mp3lame/3.98.4-26/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/opencl-runtime-loader/0.0.1-739ae8d-9/plex/stable/package/b64ae533894856536a66cf9d6456cddbab8dfede/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-media-driver/20.3.0-13/plex/stable/package/45e5eb7ea7dc7a37374cea96ebee843dbb9a51ba/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-vaapi-driver/2.4.1-11/plex/stable/package/4aac8c1cb3d92304c264990eb2eaa93e4ac52adc/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libogg/1.3.2-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/gnutls/3.7.2-0/plex/stable/package/e5f655260dba242c55d8d128de7bdc155283b4bb/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/fribidi/0.19.7-30/plex/stable/package/464531ac2a3f2ab2167bd10d1214603bc8116983/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/harfbuzz/2.6.4-47/plex/stable/package/53415d552ac96104f622ffa8d8530937a40b4271/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/nettle/3.7.3-0/plex/stable/package/33d6d59c31a8ebdda675cdb28c77aeebdbee4273/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libidn/2.0.5-49/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/fontconfig/2.13.0-68/plex/stable/package/aacc2a7710dfa87ed80d4eea45b80c93243fe456/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libxml2/2.9.11-e1bcffea-2/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/gmp/6.2.0-8/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/iconv/1.16-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/freetype2/2.10.4-15/plex/stable/package/82a00e1e4cc2e8878bb79ae9b5e2235fd8280e6a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/expat/2.2.5-28/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libuuid/1.0.3-21/plex/stable/package/841d526523d3550ac4d52807df94cbbedce37e2c/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libpthread-stubs/0.4-27/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/bzip2/1.0.6-30/plex/stable/package/618bb3c469051b52e1349cf1a297263df374d15a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libpng/1.6.37-30/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/zlib/1.2.11-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -Wl,--gc-sections -Wl,-z,noexecstack -Wl,-z,relro -g2 -gdwarf-4 -Wl,--build-id=sha1 -flto=thin -fwhole-program-vtables -Wl,--icf=all -Wl,--threads=6 -Wl,-O2 -l:libgcompat.so.0 -Wl,-rpath,'\''XORIGIN/../lib'\'' -Wl,-rpath,'\''XORIGIN/lib'\'' -Wl,--thinlto-cache-dir=/data/jenkins/conan_build/1111821918/conan/.conan/data/ffmpeg/1.6-be22e264c2-4/plex/stable/build/552c5c230951ce297093040f1ced2fb95ad90aae/lto_cache/' --extra-libs= --enable-decoder=png --enable-decoder=apng --enable-decoder=bmp --enable-decoder=mjpeg --enable-decoder=thp --enable-decoder=gif --enable-decoder=dirac --enable-decoder=ffv1 --enable-decoder=ffvhuff --enable-decoder=huffyuv --enable-decoder=rawvideo --enable-decoder=zero12v --enable-decoder=ayuv --enable-decoder=r210 --enable-decoder=v210 --enable-decoder=v210x --enable-decoder=v308 --enable-decoder=v408 --enable-decoder=v410 --enable-decoder=y41p --enable-decoder=yuv4 --enable-decoder=ansi --enable-decoder=alac --enable-decoder=flac --enable-decoder=vorbis --enable-decoder=opus --enable-decoder=pcm_f32be --enable-decoder=pcm_f32le --enable-decoder=pcm_f64be --enable-decoder=pcm_f64le --enable-decoder=pcm_lxf --enable-decoder=pcm_s16be --enable-decoder=pcm_s16be_planar --enable-decoder=pcm_s16le --enable-decoder=pcm_s16le_planar --enable-decoder=pcm_s24be --enable-decoder=pcm_s24le --enable-decoder=pcm_s24le_planar --enable-decoder=pcm_s32be --enable-decoder=pcm_s32le --enable-decoder=pcm_s32le_planar --enable-decoder=pcm_s8 --enable-decoder=pcm_s8_planar --enable-decoder=pcm_u16be --enable-decoder=pcm_u16le --enable-decoder=pcm_u24be --enable-decoder=pcm_u24le --enable-decoder=pcm_u32be --enable-decoder=pcm_u32le --enable-decoder=pcm_u8 --enable-decoder=pcm_alaw --enable-decoder=pcm_mulaw --enable-decoder=ass --enable-decoder=dvbsub --enable-decoder=dvdsub --enable-decoder=ccaption --enable-decoder=pgssub --enable-decoder=jacosub --enable-decoder=microdvd --enable-decoder=movtext --enable-decoder=mpl2 --enable-decoder=pjs --enable-decoder=realtext --enable-decoder=sami --enable-decoder=ssa --enable-decoder=stl --enable-decoder=subrip --enable-decoder=subviewer --enable-decoder=text --enable-decoder=vplayer --enable-decoder=webvtt --enable-decoder=xsub --enable-decoder=eac3_eae --enable-decoder=truehd_eae --enable-decoder=mlp_eae --enable-encoder=flac --enable-encoder=alac --enable-encoder=libvorbis --enable-encoder=libopus --enable-encoder=mjpeg --enable-encoder=wrapped_avframe --enable-encoder=ass --enable-encoder=dvbsub --enable-encoder=dvdsub --enable-encoder=movtext --enable-encoder=ssa --enable-encoder=subrip --enable-encoder=text --enable-encoder=webvtt --enable-encoder=xsub --enable-encoder=pcm_f32be --enable-encoder=pcm_f32le --enable-encoder=pcm_f64be --enable-encoder=pcm_f64le --enable-encoder=pcm_s8 --enable-encoder=pcm_s8_planar --enable-encoder=pcm_s16be --enable-encoder=pcm_s16be_planar --enable-encoder=pcm_s16le --enable-encoder=pcm_s16le_planar --enable-encoder=pcm_s24be --enable-encoder=pcm_s24le --enable-encoder=pcm_s24le_planar --enable-encoder=pcm_s32be --enable-encoder=pcm_s32le --enable-encoder=pcm_s32le_planar --enable-encoder=pcm_u8 --enable-encoder=pcm_u16be --enable-encoder=pcm_u16le --enable-encoder=pcm_u24be --enable-encoder=pcm_u24le --enable-encoder=pcm_u32be --enable-encoder=pcm_u32le --enable-encoder=h264_vaapi --enable-encoder=hevc_vaapi --enable-encoder=h264_nvenc --enable-encoder=eac3_eae --prefix=/data/jenkins/conan_build/1111821918/conan/.conan/data/ffmpeg/1.6-be22e264c2-4/plex/stable/build/552c5c230951ce297093040f1ced2fb95ad90aae/transcoder-install --enable-libzvbi --enable-gnutls --enable-libass --enable-librtmp --enable-libopus --enable-libvorbis --extra-cflags='-m64 -O3 -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g2 -gdwarf-4 -fcommon -flto=thin -fwhole-program-vtables -I/data/jenkins/conan_build/1111821918/conan/.conan/data/opus/1.2.1-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libvorbis/1.3.5-31/plex/stable/package/76eba14299c6c14bf4759b1da21aec07c9ca1a2f/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/ffnvcodec/9.0.18.2-9fdaf11-8/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/x264/161-1086f45-18/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/zvbi/0.2.35-51/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/rtmpdump/2.4-94/plex/stable/package/4168f635acadf1e81d21da6655c14c065dac9ac2/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libass/0.14.0-82/plex/stable/package/4fca6d6f1f27aa4bd2419e3401bbf5e7b4e99f27/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/mp3lame/3.98.4-26/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-media-driver/20.3.0-13/plex/stable/package/45e5eb7ea7dc7a37374cea96ebee843dbb9a51ba/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libogg/1.3.2-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/gnutls/3.7.2-0/plex/stable/package/e5f655260dba242c55d8d128de7bdc155283b4bb/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/fribidi/0.19.7-30/plex/stable/package/464531ac2a3f2ab2167bd10d1214603bc8116983/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/harfbuzz/2.6.4-47/plex/stable/package/53415d552ac96104f622ffa8d8530937a40b4271/include/harfbuzz -I/data/jenkins/conan_build/1111821918/conan/.conan/data/opencl-headers/2020.03.13-9824efd-8/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/nettle/3.7.3-0/plex/stable/package/33d6d59c31a8ebdda675cdb28c77aeebdbee4273/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libidn/2.0.5-49/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/fontconfig/2.13.0-68/plex/stable/package/aacc2a7710dfa87ed80d4eea45b80c93243fe456/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libxml2/2.9.11-e1bcffea-2/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libxml2/2.9.11-e1bcffea-2/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/include/libxml2 -I/data/jenkins/conan_build/1111821918/conan/.conan/data/gmp/6.2.0-8/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/iconv/1.16-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/freetype2/2.10.4-15/plex/stable/package/82a00e1e4cc2e8878bb79ae9b5e2235fd8280e6a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/expat/2.2.5-28/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libuuid/1.0.3-21/plex/stable/package/841d526523d3550ac4d52807df94cbbedce37e2c/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/bzip2/1.0.6-30/plex/stable/package/618bb3c469051b52e1349cf1a297263df374d15a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libpng/1.6.37-30/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/zlib/1.2.11-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -DUSING_STATIC_LIBICONV -DLIBXML_STATIC -DNDEBUG'
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |   libavutil      56. 26.100 / 56. 26.100
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |   libavcodec     58. 52.100 / 58. 52.100
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |   libavformat    58. 27.104 / 58. 27.104
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |   libavfilter     7. 49.100 /  7. 49.100
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |   libswscale      5.  4.100 /  5.  4.100
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |   libswresample   3.  4.100 /  3.  4.100
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Rescanning for external libs: '/codecs/be22e26-4019-linux-x86_64-standard/'
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpeg2video_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libinterplay_dpcm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwebp_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_lsbf_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpaf_audio_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvc1image_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp6a_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsunrast_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp7_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libg723_1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxma2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsmpeg4v2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaic_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxl_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdxa_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvqa_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmss2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_qt_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librscc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtarga_y216_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libac3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsrle_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp3on4_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcomfortnoise_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv20_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_smjpeg_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_ea_sead_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_sbpro_4_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libamrnb_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libr10k_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libscreenpresso_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtiff_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libals_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvb_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsp5x_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbethsoftvid_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhevc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhq_hqa_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmav1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsubviewer1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libzmbv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsicinaudio_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmmvideo_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaura_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_msbf_planar_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcinepak_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo5_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavui_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpcm_bluray_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libasv1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libamrwb_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libg729_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcook_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtscc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libppm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflashsv2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libprores_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpc8_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ms_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavrn_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_dk3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbinkaudio_rdft_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcdgraphics_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh261_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxbin_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libralf_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsvq1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_lsbf_planar_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhqx_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqdraw_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libatrac1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruemotion2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libevrc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_yamaha_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmvc2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/liblibx264_encoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libgsm_ms_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libjv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfraps_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libkmvc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtarga_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libescape124_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libkgv1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_encoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpam_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsdx2_dpcm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfourxm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libroq_dpcm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/liblagarith_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqdm2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdfa_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_iss_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvmdvideo_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmotionpixels_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbrender_pix_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp3adu_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmace3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmvc1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruemotion1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libasv2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libra_144_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libroq_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpeg1video_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libzlib_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libs302m_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmszh_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libffwavesynth_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpc7_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libiff_ilbm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdca_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_dk4_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmetasound_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmxpeg_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libamv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcpia_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpeg4_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmjpegb_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvcr1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_sbpro_3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libiac_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhnm4_video_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libac3_encoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_xa_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbmv_video_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmav2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/liblibmp3lame_encoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_maxis_xa_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvmnc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaasc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmts2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libutvideo_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfic_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp6f_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxma1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdxv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_r3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_xas_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_ea_eacs_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libnellymoser_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh263i_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_dat4_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp8_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsonic_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdvvideo_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libws_snd1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpgmyuv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeamad_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libptx_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmvjpeg_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmss1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsmpeg4v1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeatgq_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpaf_video_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libulti_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcscd_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxan_wc3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaura2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libyop_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcfhd_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeightbps_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhap_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpictor_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libjpegls_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_dtk_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruemotion2rt_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsol_dpcm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwnv1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsmpeg4v3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libidcin_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpcm_dvd_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libgsm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavs_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbintext_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_g722_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsipr_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_g726_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsanm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libzerocodec_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbinkaudio_dct_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp6_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libanm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqcelp_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libjpeg2000_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_r1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwavpack_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeatqi_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtdsc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsgi_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtscc2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsicinvideo_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsgirle_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ct_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_amv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcyuv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_wav_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv3image_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruespeech_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librl2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librpza_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh264_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtwinvq_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsa1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv10_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_swf_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmacker_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libinterplay_acm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_g726le_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmapro_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv40_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libra_288_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvble_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmavoice_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpcx_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmalossless_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtak_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libalias_pix_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_oki_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_thp_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmdec_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbfi_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libinterplay_video_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_msbf_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbink_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libshorten_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtmv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo4_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_lc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdpx_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_rad_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqpeg_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_apc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_adx_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdds_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvmdaudio_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_aica_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavrp_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv30_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeacmv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfrwu_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxbm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflic_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflashsv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdxtory_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libape_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmace6_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtheora_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_latm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcdxl_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqtrle_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcavs_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libon2avc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcljr_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxface_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libatrac3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_afc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libc93_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh263_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_ws_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsvq3_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_4xm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcllc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libescape130_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpgm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libatrac3p_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvc1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsvideo1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdnxhd_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libnuv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libidf_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh263p_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbmv_audio_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libloco_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_r2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp5_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_thp_le_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv1_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_vima_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtiertexseqvideo_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp9_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmimic_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libexr_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxan_wc4_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_psx_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeatgv_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeightsvx_exp_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtta_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmackaud_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libg2m_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtxd_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsnow_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxan_dpcm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdvaudio_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdss_sp_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxwd_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_sbpro_2_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libimc_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpbm_decoder.so
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | Input #0, matroska,webm, from '/media/movies/No Sudden Move (2021)/No.Sudden.Move.2021.2160p.4K.WEB.x265.10bit.HDR.AAC5.1-[YTS.MX].mkv':
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |   Metadata:
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |     ENCODER         : Lavf58.67.100
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |   Duration: 01:55:05.44, start: 0.000000, bitrate: 6389 kb/s
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:0: Video: hevc (Main 10), 1 reference frame, yuv420p10le(tv, bt709, progressive, left), 3840x2160 [SAR 1:1 DAR 16:9], 23.98 fps, 23.98 tbr, 1k tbn, 23.98 tbc (default)
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |       ENCODER         : Lavc58.122.100 libx265
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |       DURATION        : 01:55:05.442000000
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:1: Audio: aac (LC), 48000 Hz, 5.1, fltp (default)
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |       ENCODER         : Lavc58.122.100 libfdk_aac
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |       DURATION        : 01:55:05.419000000
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:2(eng): Subtitle: subrip (default)
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |       title           : English
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |       DURATION        : 01:54:19.043000000
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:3(eng): Subtitle: subrip
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |       title           : English SDH
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    |       DURATION        : 01:54:39.043000000
Sep 30 11:54:42 kent.thenursery.josc sh[863537]: plex-transcoder    | [Parsed_scale_0 @ 0x7f9beaa26300] w:3840 h:2160 flags:'bilinear' interl:0
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | Stream mapping:
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |   Stream #0:0 (hevc) -> scale (graph 0)
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |   Stream #0:1 (aac) -> aresample (graph 1)
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |   format (graph 0) -> Stream #0:0 (libx264)
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |   aresample (graph 1) -> Stream #0:1 (aac)
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | Press [q] to stop, [?] for help
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [graph_1_in_0_1 @ 0x7f9be2257200] tb:1/48000 samplefmt:fltp samplerate:48000 chlayout:0x3f
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [Parsed_aresample_0 @ 0x7f9be2257140] ch:6 chl:5.1 fmt:fltp r:48000Hz -> ch:2 chl:stereo fmt:fltp r:48000Hz
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [hevc @ 0x7f9be2628640] NVDEC capabilities:
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [hevc @ 0x7f9be2628640] format supported: yes, max_mb_count: 262144
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [hevc @ 0x7f9be2628640] min_width: 144, max_width: 8192
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [hevc @ 0x7f9be2628640] min_height: 144, max_height: 8192
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [Parsed_scale_0 @ 0x7f9be031d300] w:3840 h:2160 flags:'bilinear' interl:0
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [graph 0 input from stream 0:0 @ 0x7f9be031d5c0] w:3840 h:2160 pixfmt:p010le tb:1/1000 fr:24000/1001 sar:1/1 sws_param:flags=2
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [Parsed_scale_0 @ 0x7f9be031d300] w:3840 h:2160 fmt:p010le sar:1/1 -> w:3840 h:2160 fmt:yuv420p sar:1/1 flags:0x2
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] using SAR=1/1
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] profile High, level 5.1, 4:2:0, 8-bit
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] 264 - core 161 - H.264/MPEG-4 AVC codec - Copyleft 2003-2020 - http://www.videolan.org/x264.html - options: cabac=1 ref=1 deblock=1:0:0 analyse=0x3:0x113 me=hex subme=2 psy=1 psy_rd=1.00:0.00 mixed_ref=0 me_range=4 chroma_me=1 trellis=0 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=0 threads=6 lookahead_threads=2 sliced_threads=0 nr=0 decimate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0 direct=1 weightb=1 open_gop=0 weightp=1 keyint=250 keyint_min=23 scenecut=40 intra_refresh=0 rc_lookahead=10 rc=crf mbtree=1 crf=16.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 vbv_maxrate=27004 vbv_bufsize=54008 crf_max=0.0 nal_hrd=none filler=0 ip_ratio=1.40 aq=1:1.00
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] No bit rate set for stream 0
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'init-stream0.m4s' for writing
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [mp4 @ 0x7f9be02ff380] Empty MOOV enabled; disabling automatic bitstream filtering
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Representation 0 init segment will be written to: init-stream0.m4s
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'init-stream1.m4s' for writing
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [mp4 @ 0x7f9bc286a040] Empty MOOV enabled; disabling automatic bitstream filtering
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Representation 1 init segment will be written to: init-stream1.m4s
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | Output #0, dash, to 'dash':
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |   Metadata:
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |     encoder         : Lavf58.27.104
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:0: Video: h264 (libx264), 1 reference frame, yuv420p(left), 3840x2160 [SAR 1:1 DAR 16:9], q=-1--1, 23.98 fps, 11988 tbn, 23.98 tbc (default)
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |       encoder         : Lavc58.52.100 libx264
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |     Side data:
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |       cpb: bitrate max/min/avg: 27004000/0/0 buffer size: 54008000 vbv_delay: -1
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:1: Audio: aac (LC), 48000 Hz, stereo, fltp, delay 1024, 256 kb/s (default)
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    |       encoder         : Lavc58.52.100 aac
Sep 30 11:54:43 kent.thenursery.josc sh[863537]: plex-transcoder    | *** 1 dup!
Sep 30 11:54:44 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9be22cee00] Statistics: 0 seeks, 1 writeouts
Sep 30 11:54:44 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'chunk-stream0-00001.m4s.tmp' for writing
Sep 30 11:54:45 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9bc286c7c0] Statistics: 0 seeks, 1 writeouts
Sep 30 11:54:45 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'chunk-stream1-00001.m4s.tmp' for writing
Sep 30 11:54:50 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9bc286cb80] Statistics: 0 seeks, 11 writeouts
Sep 30 11:54:50 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Representation 0 media segment 2 written to: chunk-stream0-00001.m4s
Sep 30 11:54:50 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9bc286c2c0] Statistics: 0 seeks, 1 writeouts
Sep 30 11:54:50 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Representation 1 media segment 2 written to: chunk-stream1-00001.m4s
Sep 30 11:54:50 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'http://10.11.12.13:32400/video/:/transcode/session/k9jv6dz0g0glpdftj7p8386w/8f3a2f73-3f2f-4ebe-857a-160436f8d66f/manifest?X-Plex-Http-Pipeline=infinite' for writing
Sep 30 11:54:50 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7f9bc1a83c40] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 11:54:50 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7f9bc1a83c40] Successfully connected to 10.11.12.13 port 32400
Sep 30 11:54:50 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9be22ce900] Statistics: 0 seeks, 1 writeouts
Sep 30 11:54:50 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'chunk-stream0-00002.m4s.tmp' for writing
Sep 30 11:54:50 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'chunk-stream1-00002.m4s.tmp' for writing
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9bc286c180] Statistics: 0 seeks, 50 writeouts
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Representation 0 media segment 3 written to: chunk-stream0-00002.m4s
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9bc286c540] Statistics: 0 seeks, 1 writeouts
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Representation 1 media segment 3 written to: chunk-stream1-00002.m4s
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'http://10.11.12.13:32400/video/:/transcode/session/k9jv6dz0g0glpdftj7p8386w/8f3a2f73-3f2f-4ebe-857a-160436f8d66f/manifest?X-Plex-Http-Pipeline=infinite' for writing
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7f9bc1a83280] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7f9bc1a83280] Successfully connected to 10.11.12.13 port 32400
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9bc286c680] Statistics: 0 seeks, 1 writeouts
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'chunk-stream0-00003.m4s.tmp' for writing
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | Killing child process for task a4411730-c471-43ef-8567-422640d2e7b8
Sep 30 11:54:59 kent.thenursery.josc sh[863537]: plex-transcoder    | Removing process from taskMap
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'chunk-stream1-00003.m4s.tmp' for writing
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Received task request
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7fc307068f00] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7fc307068f00] Successfully connected to 10.11.12.13 port 32400
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | ffmpeg version be22e26-4019 Copyright (c) 2000-2019 the FFmpeg developers
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    |   built with Plex clang version 11.0.1 (https://plex.tv e0c29d5827bc4eaaa2ceb882cbeed224b0960173)
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    |   configuration: --disable-static --enable-shared --disable-libx264 --disable-hwaccels --disable-protocol=concat --external-decoder=h264 --enable-debug --enable-muxers --enable-libxml2 --fatal-warnings --disable-gmp --disable-avdevice --disable-bzlib --disable-sdl2 --disable-decoders --disable-devices --disable-encoders --disable-ffprobe --disable-ffplay --disable-doc --disable-iconv --disable-lzma --disable-schannel --disable-linux-perf --disable-mediacodec --enable-eae --disable-protocol='udp,udplite' --arch=x86_64 --target-os=linux --strip=true --cc=x86_64-linux-musl-clang --pkg-config=/data/jenkins/conan_build/1111821918/plexconantool/plex-pkg-config --pkg-config-flags=--static --enable-cuda-llvm --enable-libdrm --enable-opencl --enable-cross-compile --ar=llvm-ar --nm=llvm-nm --ranlib=llvm-ranlib --extra-ldflags='-Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/lib -m64 -L/data/jenkins/conan_build/1111821918/conan/.conan/data/opus/1.2.1-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libvorbis/1.3.5-31/plex/stable/package/76eba14299c6c14bf4759b1da21aec07c9ca1a2f/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/ffnvcodec/9.0.18.2-9fdaf11-8/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/x264/161-1086f45-18/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/zvbi/0.2.35-51/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/rtmpdump/2.4-94/plex/stable/package/4168f635acadf1e81d21da6655c14c065dac9ac2/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libass/0.14.0-82/plex/stable/package/4fca6d6f1f27aa4bd2419e3401bbf5e7b4e99f27/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/mp3lame/3.98.4-26/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/opencl-runtime-loader/0.0.1-739ae8d-9/plex/stable/package/b64ae533894856536a66cf9d6456cddbab8dfede/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-media-driver/20.3.0-13/plex/stable/package/45e5eb7ea7dc7a37374cea96ebee843dbb9a51ba/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-vaapi-driver/2.4.1-11/plex/stable/package/4aac8c1cb3d92304c264990eb2eaa93e4ac52adc/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libogg/1.3.2-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/gnutls/3.7.2-0/plex/stable/package/e5f655260dba242c55d8d128de7bdc155283b4bb/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/fribidi/0.19.7-30/plex/stable/package/464531ac2a3f2ab2167bd10d1214603bc8116983/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/harfbuzz/2.6.4-47/plex/stable/package/53415d552ac96104f622ffa8d8530937a40b4271/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/nettle/3.7.3-0/plex/stable/package/33d6d59c31a8ebdda675cdb28c77aeebdbee4273/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libidn/2.0.5-49/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/fontconfig/2.13.0-68/plex/stable/package/aacc2a7710dfa87ed80d4eea45b80c93243fe456/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libxml2/2.9.11-e1bcffea-2/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/gmp/6.2.0-8/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/iconv/1.16-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/freetype2/2.10.4-15/plex/stable/package/82a00e1e4cc2e8878bb79ae9b5e2235fd8280e6a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/expat/2.2.5-28/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libuuid/1.0.3-21/plex/stable/package/841d526523d3550ac4d52807df94cbbedce37e2c/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libpthread-stubs/0.4-27/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/bzip2/1.0.6-30/plex/stable/package/618bb3c469051b52e1349cf1a297263df374d15a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libpng/1.6.37-30/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/zlib/1.2.11-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -Wl,--gc-sections -Wl,-z,noexecstack -Wl,-z,relro -g2 -gdwarf-4 -Wl,--build-id=sha1 -flto=thin -fwhole-program-vtables -Wl,--icf=all -Wl,--threads=6 -Wl,-O2 -l:libgcompat.so.0 -Wl,-rpath,'\''XORIGIN/../lib'\'' -Wl,-rpath,'\''XORIGIN/lib'\'' -Wl,--thinlto-cache-dir=/data/jenkins/conan_build/1111821918/conan/.conan/data/ffmpeg/1.6-be22e264c2-4/plex/stable/build/552c5c230951ce297093040f1ced2fb95ad90aae/lto_cache/' --extra-libs= --enable-decoder=png --enable-decoder=apng --enable-decoder=bmp --enable-decoder=mjpeg --enable-decoder=thp --enable-decoder=gif --enable-decoder=dirac --enable-decoder=ffv1 --enable-decoder=ffvhuff --enable-decoder=huffyuv --enable-decoder=rawvideo --enable-decoder=zero12v --enable-decoder=ayuv --enable-decoder=r210 --enable-decoder=v210 --enable-decoder=v210x --enable-decoder=v308 --enable-decoder=v408 --enable-decoder=v410 --enable-decoder=y41p --enable-decoder=yuv4 --enable-decoder=ansi --enable-decoder=alac --enable-decoder=flac --enable-decoder=vorbis --enable-decoder=opus --enable-decoder=pcm_f32be --enable-decoder=pcm_f32le --enable-decoder=pcm_f64be --enable-decoder=pcm_f64le --enable-decoder=pcm_lxf --enable-decoder=pcm_s16be --enable-decoder=pcm_s16be_planar --enable-decoder=pcm_s16le --enable-decoder=pcm_s16le_planar --enable-decoder=pcm_s24be --enable-decoder=pcm_s24le --enable-decoder=pcm_s24le_planar --enable-decoder=pcm_s32be --enable-decoder=pcm_s32le --enable-decoder=pcm_s32le_planar --enable-decoder=pcm_s8 --enable-decoder=pcm_s8_planar --enable-decoder=pcm_u16be --enable-decoder=pcm_u16le --enable-decoder=pcm_u24be --enable-decoder=pcm_u24le --enable-decoder=pcm_u32be --enable-decoder=pcm_u32le --enable-decoder=pcm_u8 --enable-decoder=pcm_alaw --enable-decoder=pcm_mulaw --enable-decoder=ass --enable-decoder=dvbsub --enable-decoder=dvdsub --enable-decoder=ccaption --enable-decoder=pgssub --enable-decoder=jacosub --enable-decoder=microdvd --enable-decoder=movtext --enable-decoder=mpl2 --enable-decoder=pjs --enable-decoder=realtext --enable-decoder=sami --enable-decoder=ssa --enable-decoder=stl --enable-decoder=subrip --enable-decoder=subviewer --enable-decoder=text --enable-decoder=vplayer --enable-decoder=webvtt --enable-decoder=xsub --enable-decoder=eac3_eae --enable-decoder=truehd_eae --enable-decoder=mlp_eae --enable-encoder=flac --enable-encoder=alac --enable-encoder=libvorbis --enable-encoder=libopus --enable-encoder=mjpeg --enable-encoder=wrapped_avframe --enable-encoder=ass --enable-encoder=dvbsub --enable-encoder=dvdsub --enable-encoder=movtext --enable-encoder=ssa --enable-encoder=subrip --enable-encoder=text --enable-encoder=webvtt --enable-encoder=xsub --enable-encoder=pcm_f32be --enable-encoder=pcm_f32le --enable-encoder=pcm_f64be --enable-encoder=pcm_f64le --enable-encoder=pcm_s8 --enable-encoder=pcm_s8_planar --enable-encoder=pcm_s16be --enable-encoder=pcm_s16be_planar --enable-encoder=pcm_s16le --enable-encoder=pcm_s16le_planar --enable-encoder=pcm_s24be --enable-encoder=pcm_s24le --enable-encoder=pcm_s24le_planar --enable-encoder=pcm_s32be --enable-encoder=pcm_s32le --enable-encoder=pcm_s32le_planar --enable-encoder=pcm_u8 --enable-encoder=pcm_u16be --enable-encoder=pcm_u16le --enable-encoder=pcm_u24be --enable-encoder=pcm_u24le --enable-encoder=pcm_u32be --enable-encoder=pcm_u32le --enable-encoder=h264_vaapi --enable-encoder=hevc_vaapi --enable-encoder=h264_nvenc --enable-encoder=eac3_eae --prefix=/data/jenkins/conan_build/1111821918/conan/.conan/data/ffmpeg/1.6-be22e264c2-4/plex/stable/build/552c5c230951ce297093040f1ced2fb95ad90aae/transcoder-install --enable-libzvbi --enable-gnutls --enable-libass --enable-librtmp --enable-libopus --enable-libvorbis --extra-cflags='-m64 -O3 -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g2 -gdwarf-4 -fcommon -flto=thin -fwhole-program-vtables -I/data/jenkins/conan_build/1111821918/conan/.conan/data/opus/1.2.1-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libvorbis/1.3.5-31/plex/stable/package/76eba14299c6c14bf4759b1da21aec07c9ca1a2f/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/ffnvcodec/9.0.18.2-9fdaf11-8/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/x264/161-1086f45-18/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/zvbi/0.2.35-51/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/rtmpdump/2.4-94/plex/stable/package/4168f635acadf1e81d21da6655c14c065dac9ac2/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libass/0.14.0-82/plex/stable/package/4fca6d6f1f27aa4bd2419e3401bbf5e7b4e99f27/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/mp3lame/3.98.4-26/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-media-driver/20.3.0-13/plex/stable/package/45e5eb7ea7dc7a37374cea96ebee843dbb9a51ba/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libogg/1.3.2-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/gnutls/3.7.2-0/plex/stable/package/e5f655260dba242c55d8d128de7bdc155283b4bb/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/fribidi/0.19.7-30/plex/stable/package/464531ac2a3f2ab2167bd10d1214603bc8116983/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/harfbuzz/2.6.4-47/plex/stable/package/53415d552ac96104f622ffa8d8530937a40b4271/include/harfbuzz -I/data/jenkins/conan_build/1111821918/conan/.conan/data/opencl-headers/2020.03.13-9824efd-8/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/nettle/3.7.3-0/plex/stable/package/33d6d59c31a8ebdda675cdb28c77aeebdbee4273/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libidn/2.0.5-49/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/fontconfig/2.13.0-68/plex/stable/package/aacc2a7710dfa87ed80d4eea45b80c93243fe456/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libxml2/2.9.11-e1bcffea-2/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libxml2/2.9.11-e1bcffea-2/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/include/libxml2 -I/data/jenkins/conan_build/1111821918/conan/.conan/data/gmp/6.2.0-8/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/iconv/1.16-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/freetype2/2.10.4-15/plex/stable/package/82a00e1e4cc2e8878bb79ae9b5e2235fd8280e6a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/expat/2.2.5-28/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libuuid/1.0.3-21/plex/stable/package/841d526523d3550ac4d52807df94cbbedce37e2c/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/bzip2/1.0.6-30/plex/stable/package/618bb3c469051b52e1349cf1a297263df374d15a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libpng/1.6.37-30/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/zlib/1.2.11-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -DUSING_STATIC_LIBICONV -DLIBXML_STATIC -DNDEBUG'
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    |   libavutil      56. 26.100 / 56. 26.100
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    |   libavcodec     58. 52.100 / 58. 52.100
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    |   libavformat    58. 27.104 / 58. 27.104
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    |   libavfilter     7. 49.100 /  7. 49.100
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    |   libswscale      5.  4.100 /  5.  4.100
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    |   libswresample   3.  4.100 /  3.  4.100
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Rescanning for external libs: '/codecs/be22e26-4019-linux-x86_64-standard/'
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpeg2video_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libinterplay_dpcm_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv3_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwebp_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_lsbf_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpaf_audio_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvc1image_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp3_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp6a_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsunrast_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp7_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libg723_1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxma2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsmpeg4v2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaic_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxl_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdxa_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvqa_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmss2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_qt_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librscc_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtarga_y216_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libac3_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsrle_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp3on4_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcomfortnoise_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv20_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_smjpeg_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_ea_sead_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_sbpro_4_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libamrnb_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libr10k_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libscreenpresso_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtiff_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libals_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvb_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsp5x_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbethsoftvid_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhevc_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhq_hqa_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmav1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsubviewer1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libzmbv_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsicinaudio_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmmvideo_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaura_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_msbf_planar_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcinepak_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo5_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavui_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpcm_bluray_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libasv1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libamrwb_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libg729_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcook_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtscc_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libppm_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflashsv2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libprores_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpc8_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ms_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavrn_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp3_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_dk3_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbinkaudio_rdft_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcdgraphics_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh261_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxbin_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libralf_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsvq1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_lsbf_planar_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhqx_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqdraw_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libatrac1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruemotion2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libevrc_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_yamaha_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmvc2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/liblibx264_encoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libgsm_ms_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libjv_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfraps_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libkmvc_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtarga_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libescape124_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libkgv1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_encoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpam_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsdx2_dpcm_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfourxm_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libroq_dpcm_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/liblagarith_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqdm2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdfa_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_iss_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvmdvideo_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmotionpixels_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbrender_pix_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp3adu_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmace3_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmvc1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruemotion1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmc_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libasv2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libra_144_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libroq_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpeg1video_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libzlib_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libs302m_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmszh_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libffwavesynth_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpc7_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libiff_ilbm_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdca_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_dk4_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmetasound_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmxpeg_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libamv_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcpia_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpeg4_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmjpegb_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvcr1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_sbpro_3_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libiac_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhnm4_video_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libac3_encoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_xa_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbmv_video_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmav2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/liblibmp3lame_encoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_maxis_xa_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvmnc_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaasc_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmts2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libutvideo_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfic_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp6f_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxma1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdxv_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_r3_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_xas_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_ea_eacs_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libnellymoser_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh263i_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_dat4_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp8_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsonic_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdvvideo_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libws_snd1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpgmyuv_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeamad_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libptx_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmvjpeg_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmss1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsmpeg4v1_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeatgq_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpaf_video_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libulti_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcscd_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxan_wc3_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaura2_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libyop_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcfhd_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeightbps_decoder.so
Sep 30 11:55:00 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhap_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpictor_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libjpegls_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_dtk_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruemotion2rt_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsol_dpcm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwnv1_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsmpeg4v3_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libidcin_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpcm_dvd_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libgsm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavs_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbintext_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_g722_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsipr_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv2_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_g726_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsanm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libzerocodec_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbinkaudio_dct_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp6_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libanm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqcelp_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libjpeg2000_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_r1_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwavpack_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeatqi_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtdsc_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsgi_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtscc2_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsicinvideo_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsgirle_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ct_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_amv_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcyuv_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_wav_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv3image_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruespeech_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librl2_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librpza_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh264_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtwinvq_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsa1_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv10_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_swf_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmacker_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libinterplay_acm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_g726le_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmapro_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv40_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libra_288_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvble_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmavoice_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpcx_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmalossless_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp2_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtak_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libalias_pix_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_oki_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_thp_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmdec_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbfi_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libinterplay_video_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_msbf_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbink_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libshorten_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtmv_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo4_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_lc_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp1_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdpx_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_rad_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqpeg_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_apc_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_adx_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdds_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvmdaudio_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_aica_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavrp_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo3_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv30_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeacmv_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfrwu_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxbm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflic_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflashsv_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdxtory_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libape_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmace6_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtheora_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_latm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcdxl_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqtrle_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcavs_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libon2avc_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcljr_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxface_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libatrac3_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_afc_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libc93_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh263_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_ws_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsvq3_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_4xm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcllc_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libescape130_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpgm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libatrac3p_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvc1_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsvideo1_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdnxhd_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libnuv_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libidf_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh263p_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflv_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbmv_audio_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libloco_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_r2_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp5_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_thp_le_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv1_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_vima_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtiertexseqvideo_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp9_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmimic_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libexr_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxan_wc4_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_psx_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeatgv_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeightsvx_exp_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtta_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmackaud_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libg2m_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtxd_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsnow_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxan_dpcm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdvaudio_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdss_sp_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxwd_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_sbpro_2_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libimc_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpbm_decoder.so
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Input #0, matroska,webm, from '/media/movies/No Sudden Move (2021)/No.Sudden.Move.2021.2160p.4K.WEB.x265.10bit.HDR.AAC5.1-[YTS.MX].mkv':
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Metadata:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     ENCODER         : Lavf58.67.100
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Duration: 01:55:05.44, start: 0.000000, bitrate: 6389 kb/s
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:0: Video: hevc (Main 10), 1 reference frame, yuv420p10le(tv, bt709, progressive, left), 3840x2160 [SAR 1:1 DAR 16:9], 23.98 fps, 23.98 tbr, 1k tbn, 23.98 tbc (default)
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       ENCODER         : Lavc58.122.100 libx265
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       DURATION        : 01:55:05.442000000
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:1: Audio: aac (LC), 48000 Hz, 5.1, fltp (default)
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       ENCODER         : Lavc58.122.100 libfdk_aac
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       DURATION        : 01:55:05.419000000
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:2(eng): Subtitle: subrip (default)
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       title           : English
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       DURATION        : 01:54:19.043000000
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:3(eng): Subtitle: subrip
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       title           : English SDH
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       DURATION        : 01:54:39.043000000
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [Parsed_scale_0 @ 0x7fc305fe6ec0] w:720 h:404 flags:'bilinear' interl:0
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Stream mapping:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Stream #0:0 (hevc) -> scale (graph 0)
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Stream #0:1 (aac) -> aresample (graph 1)
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   select (graph 0) -> Stream #0:0 (libx264)
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   aresample (graph 1) -> Stream #0:1 (aac)
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Press [q] to stop, [?] for help
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [hevc @ 0x7fc2f5c1d640] NVDEC capabilities:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [hevc @ 0x7fc2f5c1d640] format supported: yes, max_mb_count: 262144
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [hevc @ 0x7fc2f5c1d640] min_width: 144, max_width: 8192
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [graph_1_in_0_1 @ 0x7fc2f5be75c0] tb:1/48000 samplefmt:fltp samplerate:48000 chlayout:0x3f
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [hevc @ 0x7fc2f5c1d640] min_height: 144, max_height: 8192
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [Parsed_aresample_0 @ 0x7fc2f5be74c0] ch:6 chl:5.1 fmt:fltp r:48000Hz -> ch:2 chl:stereo fmt:fltp r:48000Hz
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [Parsed_scale_0 @ 0x7fc2f4ac16c0] w:720 h:404 flags:'bilinear' interl:0
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [graph 0 input from stream 0:0 @ 0x7fc2f4ac1a80] w:3840 h:2160 pixfmt:p010le tb:1/1000 fr:24000/1001 sar:1/1 sws_param:flags=2
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [Parsed_scale_0 @ 0x7fc2f4ac16c0] w:3840 h:2160 fmt:p010le sar:1/1 -> w:720 h:404 fmt:yuv420p sar:404/405 flags:0x2
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7fc30001adc0] using SAR=404/405
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7fc30001adc0] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7fc30001adc0] profile High, level 3.0, 4:2:0, 8-bit
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7fc30001adc0] 264 - core 161 - H.264/MPEG-4 AVC codec - Copyleft 2003-2020 - http://www.videolan.org/x264.html - options: cabac=1 ref=1 deblock=1:0:0 analyse=0x3:0x113 me=hex subme=6 psy=1 psy_rd=1.00:0.00 mixed_ref=0 me_range=4 chroma_me=1 trellis=0 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=-2 threads=6 lookahead_threads=1 sliced_threads=0 nr=0 decimate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0 direct=1 weightb=1 open_gop=0 weightp=1 keyint=250 keyint_min=23 scenecut=40 intra_refresh=0 rc_lookahead=10 rc=crf mbtree=1 crf=21.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 vbv_maxrate=947 vbv_bufsize=1894 crf_max=0.0 nal_hrd=none filler=0 ip_ratio=1.40 aq=1:1.00
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9bc286ca40] Statistics: 0 seeks, 12 writeouts
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Representation 0 media segment 4 written to: chunk-stream0-00003.m4s
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] No bit rate set for stream 0
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9bc286ccc0] Statistics: 0 seeks, 1 writeouts
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Opening 'init-stream0.m4s' for writing
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Representation 1 media segment 4 written to: chunk-stream1-00003.m4s
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [mp4 @ 0x7fc2f4aa2d00] Empty MOOV enabled; disabling automatic bitstream filtering
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7f9beaa0d080] Opening 'http://10.11.12.13:32400/video/:/transcode/session/k9jv6dz0g0glpdftj7p8386w/8f3a2f73-3f2f-4ebe-857a-160436f8d66f/manifest?X-Plex-Http-Pipeline=infinite' for writing
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7f9bc1a83280] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Representation 0 init segment will be written to: init-stream0.m4s
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Opening 'init-stream1.m4s' for writing
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7f9bc1a83280] Successfully connected to 10.11.12.13 port 32400
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [mp4 @ 0x7fc2d63a0040] Empty MOOV enabled; disabling automatic bitstream filtering
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9be22ce900] Statistics: 0 seeks, 1 writeouts
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Representation 1 init segment will be written to: init-stream1.m4s
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Output #0, dash, to 'dash':
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Metadata:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | frame=  165 fps=9.0 q=-1.0 Lsize=N/A time=00:00:07.01 bitrate=N/A dup=1 drop=0 speed=0.383x
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     encoder         : Lavf58.27.104video:18339kB audio:2kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Input file #0 (/media/movies/No Sudden Move (2021)/No.Sudden.Move.2021.2160p.4K.WEB.x265.10bit.HDR.AAC5.1-[YTS.MX].mkv):
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:0: Video: h264 (libx264), 1 reference frame, yuv420p(left), 720x404 [SAR 404:405 DAR 16:9], q=-1--1, 23.98 fps, 11988 tbn, 23.98 tbc (default)
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Input stream #0:0 (video): 170 packets read (4197027 bytes); 165 frames decoded;
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Input stream #0:1 (audio): 329 packets read (336896 bytes); 329 frames decoded (336896 samples);
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       encoder         : Lavc58.52.100 libx264
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Input stream #0:2 (subtitle): 0 packets read (0 bytes);
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Side data:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Input stream #0:3 (subtitle): 0 packets read (0 bytes);
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Total: 499 packets (4533923 bytes) demuxed
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       cpb: bitrate max/min/avg: 947000/0/0 buffer size: 1894000 vbv_delay: -1
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Stream #0:1: Audio: aac (LC), 48000 Hz, stereo, fltp, delay 1024, 162 kb/s (default)
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Output file #0 (dash):
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Output stream #0:0 (video): 165 frames encoded; 165 packets muxed (18778796 bytes);
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |     Metadata:
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |       encoder         : Lavc58.52.100 aac
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Output stream #0:1 (audio): 329 frames encoded (336896 samples); 330 packets muxed (2014 bytes);
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    |   Total: 495 packets (18780810 bytes) muxed
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] frame I:4     Avg QP: 7.46  size:219229
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] frame P:41    Avg QP:10.80  size:132381
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] frame B:120   Avg QP:12.03  size:103946
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] consecutive B-frames:  2.4%  1.2%  1.8% 94.5%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] mb I  I16..4: 44.5% 50.5%  5.1%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] mb P  I16..4:  8.3% 42.5%  1.6%  P16..4:  3.2%  1.9%  1.1%  0.0%  0.0%    skip:41.4%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] mb B  I16..4:  4.7% 31.2%  0.7%  B16..8:  6.1%  2.8%  0.3%  direct: 4.6%  skip:49.5%  L0:44.4% L1:38.3% BI:17.3%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] 8x8 transform intra:81.9% inter:63.8%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] coded y,uvDC,uvAC intra: 72.2% 37.9% 13.5% inter: 6.7% 7.1% 0.2%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] i16 v,h,dc,p: 53% 18% 25%  3%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] i8 v,h,dc,ddl,ddr,vr,hd,vl,hu: 27% 19% 28%  4%  5%  4%  5%  3%  5%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] i4 v,h,dc,ddl,ddr,vr,hd,vl,hu: 21% 18% 14%  8% 12%  8%  8%  6%  6%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] i8c dc,h,v,p: 60% 20% 16%  3%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] Weighted P-Frames: Y:31.7% UV:31.7%
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [libx264 @ 0x7f9beaa0fdc0] kb/s:21828.97
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [aac @ 0x7f9beaa10b40] Qavg: 65536.000
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7f9bf09af600] Statistics: 4551522 bytes read, 0 seeks
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Exiting normally, received signal 15.
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Completed transcode
Sep 30 11:55:01 kent.thenursery.josc sh[863537]: plex-transcoder    | Removing process from taskMap
Sep 30 11:55:05 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7fc2f58c3b80] Statistics: 0 seeks, 1 writeouts
Sep 30 11:55:05 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Opening 'chunk-stream0-00003.m4s.tmp' for writing
Sep 30 11:55:05 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7fc2d63aa7c0] Statistics: 0 seeks, 1 writeouts
Sep 30 11:55:05 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Opening 'chunk-stream1-00003.m4s.tmp' for writing
Sep 30 11:55:08 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7fc2d63aa180] Statistics: 0 seeks, 1 writeouts
Sep 30 11:55:08 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Representation 0 media segment 4 written to: chunk-stream0-00003.m4s
Sep 30 11:55:08 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7fc2d63aa540] Statistics: 0 seeks, 1 writeouts
Sep 30 11:55:08 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Representation 1 media segment 4 written to: chunk-stream1-00003.m4s
Sep 30 11:55:08 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Opening 'http://10.11.12.13:32400/video/:/transcode/session/k9jv6dz0g0glpdftj7p8386w/0c224a97-8be7-4b3e-9857-27f2250cfbd7/manifest?X-Plex-Http-Pipeline=infinite' for writing
Sep 30 11:55:08 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7fc2f4ac6700] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 11:55:08 kent.thenursery.josc sh[863537]: plex-transcoder    | [tcp @ 0x7fc2f4ac6700] Successfully connected to 10.11.12.13 port 32400
Sep 30 11:55:08 kent.thenursery.josc sh[863537]: plex-transcoder    | [AVIOContext @ 0x7fc2d63aab80] Statistics: 0 seeks, 1 writeouts
Sep 30 11:55:08 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Opening 'chunk-stream0-00004.m4s.tmp' for writing
Sep 30 11:55:08 kent.thenursery.josc sh[863537]: plex-transcoder    | [dash @ 0x7fc300018040] Opening 'chunk-stream1-00004.m4s.tmp' for writing
```

Worker smi output:

```
Every 0.5s: nvidia-smi                                                    kent.thenursery.josc: Thu Sep 30 11:55:08 2021

Thu Sep 30 11:55:08 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.74	  Driver Version: 470.74       CUDA Version: 11.4     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA GeForce ...  Off  | 00000000:13:00.0 Off |                  N/A |
|  0%   64C    P2    30W / 120W |    231MiB /  6078MiB |      1%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A    926700      C   ...diaserver/Plex Transcoder      229MiB |
+-----------------------------------------------------------------------------+
```