### PR TITLE
Worker hw transcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ The image extends the [LinuxServer Plex](https://hub.docker.com/r/linuxserver/pl
 
 | Parameter | Function |
 | :----: | --- |
+| `FFMPEG_HWACCEL` | Allows a [hwaccel decoder](https://trac.ffmpeg.org/wiki/HWAccelIntro) to be passed to ffmpeg such as `nvdec` or `dvxa2` |
 | `LISTENING_PORT` | Port where workers expose the internal healthcheck |
 | `STAT_CPU_INTERVAL` | Frequency at which the worker sends stats to the orchestrator (in ms). Default 2000 |
 | `ORCHESTRATOR_URL` | The url where the orchestrator service can be reached (ex: http://plex-orchestrator:3500) |


### PR DESCRIPTION
This PR allows hardware acceleration to be hinted on worker nodes. 

A new optional env variable `FFMPEG_HWACCEL` is added to the worker docker compose, this is then added to the payload prior to transcoding. This allows different workers to either use hardware acceleration, or not, or different drivers, depending on their hardware configuration.

Worker logs:

```
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Received task request
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Setting hwaccel to nvdec
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | [tcp @ 0x7f3ea5901f00] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | [tcp @ 0x7f3ea5901f00] Successfully connected to 10.11.12.13 port 32400
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | ffmpeg version be22e26-4019 Copyright (c) 2000-2019 the FFmpeg developers
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    |   built with Plex clang version 11.0.1 (https://plex.tv e0c29d5827bc4eaaa2ceb882cbeed224b0960173)
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    |   configuration: --disable-static --enable-shared --disable-libx264 --disable-hwaccels --disable-protocol=concat --external-decoder=h264 --enable-debug --enable-muxers --enable-libxml2 --fatal-warnings --disable-gmp --disable-avdevice --disable-bzlib --disable-sdl2 --disable-decoders --disable-devices --disable-encoders --disable-ffprobe --disable-ffplay --disable-doc --disable-iconv --disable-lzma --disable-schannel --disable-linux-perf --disable-mediacodec --enable-eae --disable-protocol='udp,udplite' --arch=x86_64 --target-os=linux --strip=true --cc=x86_64-linux-musl-clang --pkg-config=/data/jenkins/conan_build/1111821918/plexconantool/plex-pkg-config --pkg-config-flags=--static --enable-cuda-llvm --enable-libdrm --enable-opencl --enable-cross-compile --ar=llvm-ar --nm=llvm-nm --ranlib=llvm-ranlib --extra-ldflags='-Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/lib -Wl,-rpath,/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/lib -m64 -L/data/jenkins/conan_build/1111821918/conan/.conan/data/opus/1.2.1-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libvorbis/1.3.5-31/plex/stable/package/76eba14299c6c14bf4759b1da21aec07c9ca1a2f/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/ffnvcodec/9.0.18.2-9fdaf11-8/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/x264/161-1086f45-18/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/zvbi/0.2.35-51/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/rtmpdump/2.4-94/plex/stable/package/4168f635acadf1e81d21da6655c14c065dac9ac2/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libass/0.14.0-82/plex/stable/package/4fca6d6f1f27aa4bd2419e3401bbf5e7b4e99f27/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/mp3lame/3.98.4-26/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/opencl-runtime-loader/0.0.1-739ae8d-9/plex/stable/package/b64ae533894856536a66cf9d6456cddbab8dfede/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-media-driver/20.3.0-13/plex/stable/package/45e5eb7ea7dc7a37374cea96ebee843dbb9a51ba/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-vaapi-driver/2.4.1-11/plex/stable/package/4aac8c1cb3d92304c264990eb2eaa93e4ac52adc/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libogg/1.3.2-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/gnutls/3.7.2-0/plex/stable/package/e5f655260dba242c55d8d128de7bdc155283b4bb/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/fribidi/0.19.7-30/plex/stable/package/464531ac2a3f2ab2167bd10d1214603bc8116983/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/harfbuzz/2.6.4-47/plex/stable/package/53415d552ac96104f622ffa8d8530937a40b4271/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/nettle/3.7.3-0/plex/stable/package/33d6d59c31a8ebdda675cdb28c77aeebdbee4273/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libidn/2.0.5-49/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/fontconfig/2.13.0-68/plex/stable/package/aacc2a7710dfa87ed80d4eea45b80c93243fe456/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libxml2/2.9.11-e1bcffea-2/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/gmp/6.2.0-8/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/iconv/1.16-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/freetype2/2.10.4-15/plex/stable/package/82a00e1e4cc2e8878bb79ae9b5e2235fd8280e6a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/expat/2.2.5-28/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libuuid/1.0.3-21/plex/stable/package/841d526523d3550ac4d52807df94cbbedce37e2c/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libpthread-stubs/0.4-27/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/bzip2/1.0.6-30/plex/stable/package/618bb3c469051b52e1349cf1a297263df374d15a/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/libpng/1.6.37-30/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/lib -L/data/jenkins/conan_build/1111821918/conan/.conan/data/zlib/1.2.11-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/lib -Wl,--gc-sections -Wl,-z,noexecstack -Wl,-z,relro -g2 -gdwarf-4 -Wl,--build-id=sha1 -flto=thin -fwhole-program-vtables -Wl,--icf=all -Wl,--threads=6 -Wl,-O2 -l:libgcompat.so.0 -Wl,-rpath,'\''XORIGIN/../lib'\'' -Wl,-rpath,'\''XORIGIN/lib'\'' -Wl,--thinlto-cache-dir=/data/jenkins/conan_build/1111821918/conan/.conan/data/ffmpeg/1.6-be22e264c2-4/plex/stable/build/552c5c230951ce297093040f1ced2fb95ad90aae/lto_cache/' --extra-libs= --enable-decoder=png --enable-decoder=apng --enable-decoder=bmp --enable-decoder=mjpeg --enable-decoder=thp --enable-decoder=gif --enable-decoder=dirac --enable-decoder=ffv1 --enable-decoder=ffvhuff --enable-decoder=huffyuv --enable-decoder=rawvideo --enable-decoder=zero12v --enable-decoder=ayuv --enable-decoder=r210 --enable-decoder=v210 --enable-decoder=v210x --enable-decoder=v308 --enable-decoder=v408 --enable-decoder=v410 --enable-decoder=y41p --enable-decoder=yuv4 --enable-decoder=ansi --enable-decoder=alac --enable-decoder=flac --enable-decoder=vorbis --enable-decoder=opus --enable-decoder=pcm_f32be --enable-decoder=pcm_f32le --enable-decoder=pcm_f64be --enable-decoder=pcm_f64le --enable-decoder=pcm_lxf --enable-decoder=pcm_s16be --enable-decoder=pcm_s16be_planar --enable-decoder=pcm_s16le --enable-decoder=pcm_s16le_planar --enable-decoder=pcm_s24be --enable-decoder=pcm_s24le --enable-decoder=pcm_s24le_planar --enable-decoder=pcm_s32be --enable-decoder=pcm_s32le --enable-decoder=pcm_s32le_planar --enable-decoder=pcm_s8 --enable-decoder=pcm_s8_planar --enable-decoder=pcm_u16be --enable-decoder=pcm_u16le --enable-decoder=pcm_u24be --enable-decoder=pcm_u24le --enable-decoder=pcm_u32be --enable-decoder=pcm_u32le --enable-decoder=pcm_u8 --enable-decoder=pcm_alaw --enable-decoder=pcm_mulaw --enable-decoder=ass --enable-decoder=dvbsub --enable-decoder=dvdsub --enable-decoder=ccaption --enable-decoder=pgssub --enable-decoder=jacosub --enable-decoder=microdvd --enable-decoder=movtext --enable-decoder=mpl2 --enable-decoder=pjs --enable-decoder=realtext --enable-decoder=sami --enable-decoder=ssa --enable-decoder=stl --enable-decoder=subrip --enable-decoder=subviewer --enable-decoder=text --enable-decoder=vplayer --enable-decoder=webvtt --enable-decoder=xsub --enable-decoder=eac3_eae --enable-decoder=truehd_eae --enable-decoder=mlp_eae --enable-encoder=flac --enable-encoder=alac --enable-encoder=libvorbis --enable-encoder=libopus --enable-encoder=mjpeg --enable-encoder=wrapped_avframe --enable-encoder=ass --enable-encoder=dvbsub --enable-encoder=dvdsub --enable-encoder=movtext --enable-encoder=ssa --enable-encoder=subrip --enable-encoder=text --enable-encoder=webvtt --enable-encoder=xsub --enable-encoder=pcm_f32be --enable-encoder=pcm_f32le --enable-encoder=pcm_f64be --enable-encoder=pcm_f64le --enable-encoder=pcm_s8 --enable-encoder=pcm_s8_planar --enable-encoder=pcm_s16be --enable-encoder=pcm_s16be_planar --enable-encoder=pcm_s16le --enable-encoder=pcm_s16le_planar --enable-encoder=pcm_s24be --enable-encoder=pcm_s24le --enable-encoder=pcm_s24le_planar --enable-encoder=pcm_s32be --enable-encoder=pcm_s32le --enable-encoder=pcm_s32le_planar --enable-encoder=pcm_u8 --enable-encoder=pcm_u16be --enable-encoder=pcm_u16le --enable-encoder=pcm_u24be --enable-encoder=pcm_u24le --enable-encoder=pcm_u32be --enable-encoder=pcm_u32le --enable-encoder=h264_vaapi --enable-encoder=hevc_vaapi --enable-encoder=h264_nvenc --enable-encoder=eac3_eae --prefix=/data/jenkins/conan_build/1111821918/conan/.conan/data/ffmpeg/1.6-be22e264c2-4/plex/stable/build/552c5c230951ce297093040f1ced2fb95ad90aae/transcoder-install --enable-libzvbi --enable-gnutls --enable-libass --enable-librtmp --enable-libopus --enable-libvorbis --extra-cflags='-m64 -O3 -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g2 -gdwarf-4 -fcommon -flto=thin -fwhole-program-vtables -I/data/jenkins/conan_build/1111821918/conan/.conan/data/opus/1.2.1-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libvorbis/1.3.5-31/plex/stable/package/76eba14299c6c14bf4759b1da21aec07c9ca1a2f/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/ffnvcodec/9.0.18.2-9fdaf11-8/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/x264/161-1086f45-18/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/zvbi/0.2.35-51/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/rtmpdump/2.4-94/plex/stable/package/4168f635acadf1e81d21da6655c14c065dac9ac2/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libass/0.14.0-82/plex/stable/package/4fca6d6f1f27aa4bd2419e3401bbf5e7b4e99f27/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/mp3lame/3.98.4-26/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-media-driver/20.3.0-13/plex/stable/package/45e5eb7ea7dc7a37374cea96ebee843dbb9a51ba/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libogg/1.3.2-27/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/gnutls/3.7.2-0/plex/stable/package/e5f655260dba242c55d8d128de7bdc155283b4bb/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/fribidi/0.19.7-30/plex/stable/package/464531ac2a3f2ab2167bd10d1214603bc8116983/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/harfbuzz/2.6.4-47/plex/stable/package/53415d552ac96104f622ffa8d8530937a40b4271/include/harfbuzz -I/data/jenkins/conan_build/1111821918/conan/.conan/data/opencl-headers/2020.03.13-9824efd-8/plex/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libva/2.9.0-13/plex/stable/package/f0f4893209b867ce448a96e25ef4d6b158311557/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/intel-gmmlib/20.3.2-9/plex/stable/package/d7d5d1f35ff92a8c39da6b47605055e839a42a9c/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/nettle/3.7.3-0/plex/stable/package/33d6d59c31a8ebdda675cdb28c77aeebdbee4273/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libidn/2.0.5-49/plex/stable/package/7366a567f554439fb9e7a3415c9d1c2ea2b75360/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/fontconfig/2.13.0-68/plex/stable/package/aacc2a7710dfa87ed80d4eea45b80c93243fe456/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libdrm/2.4.100-10/plex/stable/package/869d62d4ee937e324519890369f81af6dafb3b71/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libxml2/2.9.11-e1bcffea-2/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libxml2/2.9.11-e1bcffea-2/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/include/libxml2 -I/data/jenkins/conan_build/1111821918/conan/.conan/data/gmp/6.2.0-8/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/iconv/1.16-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/freetype2/2.10.4-15/plex/stable/package/82a00e1e4cc2e8878bb79ae9b5e2235fd8280e6a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/expat/2.2.5-28/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libuuid/1.0.3-21/plex/stable/package/841d526523d3550ac4d52807df94cbbedce37e2c/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libpciaccess/0.16-8/plex/stable/package/7763a87432c78a82fd36373080b064286892cea3/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/bzip2/1.0.6-30/plex/stable/package/618bb3c469051b52e1349cf1a297263df374d15a/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/libpng/1.6.37-30/plex/stable/package/33406d37abb556848190dcd6097a9849aa894baf/include -I/data/jenkins/conan_build/1111821918/conan/.conan/data/zlib/1.2.11-24/plex/stable/package/64edc78a49b81c2615dad7b22a9ac90cc029860a/include -DUSING_STATIC_LIBICONV -DLIBXML_STATIC -DNDEBUG'
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    |   libavutil      56. 26.100 / 56. 26.100
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    |   libavcodec     58. 52.100 / 58. 52.100
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    |   libavformat    58. 27.104 / 58. 27.104
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    |   libavfilter     7. 49.100 /  7. 49.100
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    |   libswscale      5.  4.100 /  5.  4.100
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    |   libswresample   3.  4.100 /  3.  4.100
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Rescanning for external libs: '/codecs/be22e26-4019-linux-x86_64-standard/'
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpeg2video_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libinterplay_dpcm_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv3_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwebp_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_lsbf_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpaf_audio_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvc1image_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp3_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp6a_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsunrast_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp7_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libg723_1_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxma2_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsmpeg4v2_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaic_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxl_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdxa_decoder.so
Sep 30 21:24:03 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvqa_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmss2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_qt_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librscc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtarga_y216_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libac3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsrle_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp3on4_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcomfortnoise_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv20_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_smjpeg_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_ea_sead_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_sbpro_4_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libamrnb_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libr10k_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libscreenpresso_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtiff_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libals_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvb_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsp5x_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbethsoftvid_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhevc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhq_hqa_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmav1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsubviewer1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libzmbv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsicinaudio_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmmvideo_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaura_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_msbf_planar_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcinepak_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo5_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavui_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpcm_bluray_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libasv1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libamrwb_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libg729_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcook_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtscc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libppm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflashsv2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libprores_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpc8_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ms_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavrn_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_dk3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbinkaudio_rdft_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcdgraphics_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh261_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxbin_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libralf_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsvq1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_lsbf_planar_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhqx_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqdraw_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libatrac1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruemotion2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libevrc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_yamaha_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmvc2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/liblibx264_encoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libgsm_ms_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libjv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfraps_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libkmvc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtarga_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libescape124_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libkgv1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_encoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpam_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsdx2_dpcm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfourxm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libroq_dpcm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/liblagarith_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqdm2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdfa_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_iss_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvmdvideo_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmotionpixels_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbrender_pix_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp3adu_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmace3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmvc1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruemotion1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libasv2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libra_144_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libroq_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpeg1video_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libzlib_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libs302m_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmszh_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libffwavesynth_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpc7_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libiff_ilbm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdca_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_dk4_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmetasound_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmxpeg_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libamv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcpia_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmpeg4_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmjpegb_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvcr1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_sbpro_3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libiac_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhnm4_video_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libac3_encoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_xa_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbmv_video_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmav2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/liblibmp3lame_encoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_maxis_xa_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvmnc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaasc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmts2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libutvideo_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfic_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp6f_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxma1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdxv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_r3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_xas_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_ea_eacs_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libnellymoser_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh263i_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_dat4_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp8_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsonic_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdvvideo_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libws_snd1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpgmyuv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeamad_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libptx_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmvjpeg_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmss1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsmpeg4v1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeatgq_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpaf_video_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libulti_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcscd_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxan_wc3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaura2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libyop_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcfhd_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeightbps_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libhap_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpictor_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libjpegls_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_dtk_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruemotion2rt_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsol_dpcm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwnv1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsmpeg4v3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libidcin_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpcm_dvd_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libgsm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavs_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbintext_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_g722_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsipr_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_g726_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsanm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libzerocodec_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbinkaudio_dct_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp6_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libanm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqcelp_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libjpeg2000_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_r1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwavpack_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeatqi_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtdsc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsgi_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtscc2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsicinvideo_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsgirle_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ct_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_amv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcyuv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_wav_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv3image_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtruespeech_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librl2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librpza_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh264_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtwinvq_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsa1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv10_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_swf_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmacker_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libinterplay_acm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_g726le_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmapro_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv40_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libra_288_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvble_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmavoice_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpcx_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmalossless_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtak_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libalias_pix_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_oki_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_thp_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmdec_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbfi_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libinterplay_video_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdsd_msbf_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbink_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libshorten_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtmv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo4_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_lc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmp1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdpx_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_rad_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqpeg_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_apc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_adx_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdds_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvmdaudio_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_aica_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libavrp_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libindeo3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/librv30_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeacmv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libfrwu_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxbm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflic_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflashsv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdxtory_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libape_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmace6_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtheora_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libaac_latm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcdxl_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libqtrle_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcavs_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libon2avc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcljr_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxface_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libatrac3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_afc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libc93_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh263_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ima_ws_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsvq3_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_4xm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libcllc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libescape130_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpgm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libatrac3p_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvc1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmsvideo1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdnxhd_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libnuv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libidf_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libh263p_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libflv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libbmv_audio_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libloco_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_ea_r2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp5_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_thp_le_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libwmv1_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_vima_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtiertexseqvideo_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libvp9_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libmimic_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libexr_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxan_wc4_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_psx_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeatgv_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libeightsvx_exp_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtta_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsmackaud_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libg2m_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libtxd_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libsnow_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxan_dpcm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdvaudio_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libdss_sp_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libxwd_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libadpcm_sbpro_2_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libimc_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Loading external lib /codecs/be22e26-4019-linux-x86_64-standard/libpbm_decoder.so
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | [h264 @ 0x7f3ea3cef040] Reinit context to 1920x816, pix_fmt: yuv420p
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | [h264 @ 0x7f3ea3cef040] Increasing reorder buffer to 1
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | Input #0, matroska,webm, from '/media/movies/Kung Pow- Enter the Fist (2002)/Kung.Pow.Enter.The.Fist.2002.1080p.WEB-DL.DD5.1.H264-FGT.mkv':
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |   Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     title           :
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     encoder         : libebml v1.3.1 + libmatroska v1.4.2
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     creation_time   : 2015-10-10T13:08:56.000000Z
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |   Duration: 01:27:18.66, start: 0.000000, bitrate: 4457 kb/s
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:0: start 0.000000, end 365.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : The Chosen One
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:1: start 365.000000, end 577.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : The Wanderer (Main Titles)
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:2: start 577.000000, end 759.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : One-Man Army
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:3: start 759.000000, end 1131.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Help from Master Tang
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:4: start 1131.000000, end 1183.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Wimp Lo's Jealousy
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:5: start 1183.000000, end 1243.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : In Training
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:6: start 1243.000000, end 1375.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : A Challenge
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:7: start 1375.000000, end 1555.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Master Pain Performs
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:8: start 1555.000000, end 1688.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : The Test
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:9: start 1688.000000, end 1854.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Whoa
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:10: start 1854.000000, end 1983.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Master Tang's Challenge
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:11: start 1983.000000, end 2070.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Ling's Plea
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:12: start 2070.000000, end 2232.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : The Kung-Fu Cow
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:13: start 2232.000000, end 2383.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Not Ready Yet
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:14: start 2383.000000, end 2634.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : A Warning
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:15: start 2634.000000, end 2875.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Mu-Shu Fasa
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:16: start 2875.000000, end 3124.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Betty's Killing Spree
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:17: start 3124.000000, end 3204.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Captured
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:18: start 3204.000000, end 3257.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Intermission
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:19: start 3257.000000, end 3460.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Dead or Alive?
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:20: start 3460.000000, end 3689.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Toughening Up
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:21: start 3689.000000, end 3822.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : The Evil Council
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:22: start 3822.000000, end 3913.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : How to Beat Betty
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:23: start 3913.000000, end 4081.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : The Chosen One's Challenge
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:24: start 4081.000000, end 4207.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : French Aliens
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:25: start 4207.000000, end 4364.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Betty Beaten
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:26: start 4364.000000, end 4425.000000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : The Sequel
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Chapter #0:27: start 4425.000000, end 5238.656000
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : End Titles
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Stream #0:0(eng): Video: h264 (High), 1 reference frame, yuv420p(tv, bt709, progressive, topleft), 1918x816 (1920x816) [SAR 1:1 DAR 959:408], 23.98 fps, 23.98 tbr, 1k tbn, 2k tbc (default)
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Kung.Pow.Enter.The.Fist.2002.1080p.WEB-DL.DD5.1.H264-FGT
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Stream #0:1(eng): Audio: ac3, 48000 Hz, 5.1(side), s16p, 384 kb/s (default)
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       title           : Kung.Pow.Enter.The.Fist.2002.1080p.WEB-DL.DD5.1.H264-FGT
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Stream #0:2(eng): Subtitle: subrip
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Stream #0:3(spa): Subtitle: subrip
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Stream #0:4: Video: mjpeg (Baseline), 1 reference frame, yuvj444p(pc, bt470bg/unknown/unknown, center), 120x176, 90k tbr, 90k tbn, 90k tbc
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       filename        : small_cover.jpg
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       mimetype        : image/jpeg
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Stream #0:5: Video: mjpeg (Baseline), 1 reference frame, yuvj444p(pc, bt470bg/unknown/unknown, center), 213x120, 90k tbr, 90k tbn, 90k tbc
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       filename        : small_cover_land.jpg
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       mimetype        : image/jpeg
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Stream #0:6: Video: mjpeg (Baseline), 1 reference frame, yuvj444p(pc, bt470bg/unknown/unknown, center), 600x882, 90k tbr, 90k tbn, 90k tbc
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       filename        : cover.jpg
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       mimetype        : image/jpeg
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Stream #0:7: Video: mjpeg (Baseline), 1 reference frame, yuvj444p(pc, bt470bg/unknown/unknown, center), 1067x600, 90k tbr, 90k tbn, 90k tbc
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       filename        : cover_land.jpg
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    |       mimetype        : image/jpeg
Sep 30 21:24:04 kent.thenursery.josc sh[15594]: plex-transcoder    | [Parsed_scale_0 @ 0x7f3e9ea8c600] w:1918 h:816 flags:'bilinear' interl:0
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | Stream mapping:
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |   Stream #0:0 (h264) -> scale (graph 0)
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |   Stream #0:1 (ac3) -> aresample (graph 1)
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |   format (graph 0) -> Stream #0:0 (libx264)
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |   aresample (graph 1) -> Stream #0:1 (aac)
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | Press [q] to stop, [?] for help
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [graph_1_in_0_1 @ 0x7f3e951f1c80] tb:1/48000 samplefmt:fltp samplerate:48000 chlayout:0x60f
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [Parsed_aresample_0 @ 0x7f3e951f1b80] ch:6 chl:5.1(side) fmt:fltp r:48000Hz -> ch:2 chl:stereo fmt:fltp r:48000Hz
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [h264 @ 0x7f3e95208340] NVDEC capabilities:
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [h264 @ 0x7f3e95208340] format supported: yes, max_mb_count: 65536
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [h264 @ 0x7f3e95208340] min_width: 48, max_width: 4096
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [h264 @ 0x7f3e95208340] min_height: 16, max_height: 4096
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [h264 @ 0x7f3e95208340] Reinit context to 1920x816, pix_fmt: cuda
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [Parsed_scale_0 @ 0x7f3e94296c40] w:1918 h:816 flags:'bilinear' interl:0
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [graph 0 input from stream 0:0 @ 0x7f3e90cd7040] w:1918 h:816 pixfmt:nv12 tb:1/1000 fr:2997/125 sar:1/1 sws_param:flags=2
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [Parsed_scale_0 @ 0x7f3e94296c40] w:1918 h:816 fmt:nv12 sar:1/1 -> w:1918 h:816 fmt:nv12 sar:1/1 flags:0x2
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] using SAR=1/1
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] profile High, level 4.0, 4:2:0, 8-bit
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] 264 - core 161 - H.264/MPEG-4 AVC codec - Copyleft 2003-2020 - http://www.videolan.org/x264.html - options: cabac=1 ref=1 deblock=1:0:0 analyse=0x3:0x113 me=hex subme=2 psy=1 psy_rd=1.00:0.00 mixed_ref=0 me_range=4 chroma_me=1 trellis=0 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=0 threads=6 lookahead_threads=2 sliced_threads=0 nr=0 decimate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0 direct=1 weightb=1 open_gop=0 weightp=1 keyint=250 keyint_min=23 scenecut=40 intra_refresh=0 rc_lookahead=10 rc=crf mbtree=1 crf=16.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 vbv_maxrate=6106 vbv_bufsize=12212 crf_max=0.0 nal_hrd=none filler=0 ip_ratio=1.40 aq=1:1.00
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] No bit rate set for stream 0
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'init-stream0.m4s' for writing
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [mp4 @ 0x7f3e94264d00] Empty MOOV enabled; disabling automatic bitstream filtering
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Representation 0 init segment will be written to: init-stream0.m4s
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'init-stream1.m4s' for writing
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [mp4 @ 0x7f3e94265340] Empty MOOV enabled; disabling automatic bitstream filtering
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Representation 1 init segment will be written to: init-stream1.m4s
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | Output #0, dash, to 'dash':
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |   Metadata:
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |     encoder         : Lavf58.27.104
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |     Stream #0:0(eng): Video: h264 (libx264), 1 reference frame, nv12(topleft), 1918x816 [SAR 1:1 DAR 959:408], q=-1--1, 23.98 fps, 11988 tbn, 23.98 tbc (default)
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |       encoder         : Lavc58.52.100 libx264
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |     Side data:
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |       cpb: bitrate max/min/avg: 6106000/0/0 buffer size: 12212000 vbv_delay: -1
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |     Stream #0:1(eng): Audio: aac (LC), 48000 Hz, stereo, fltp, delay 1024, 256 kb/s (default)
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |     Metadata:
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    |       encoder         : Lavc58.52.100 aac
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e90181700] Statistics: 0 seeks, 1 writeouts
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'chunk-stream0-00001.m4s.tmp' for writing
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e90181ac0] Statistics: 0 seeks, 1 writeouts
Sep 30 21:24:05 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'chunk-stream1-00001.m4s.tmp' for writing
Sep 30 21:24:06 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e90181700] Statistics: 0 seeks, 8 writeouts
Sep 30 21:24:06 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Representation 0 media segment 2 written to: chunk-stream0-00001.m4s
Sep 30 21:24:06 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e91004100] Statistics: 0 seeks, 1 writeouts
Sep 30 21:24:07 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Representation 1 media segment 2 written to: chunk-stream1-00001.m4s
Sep 30 21:24:07 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'http://10.11.12.13:32400/video/:/transcode/session/o9kp1hsky6b7lveao46qpb4b/5742c0b5-7b4a-49ac-b92d-6944bea6947e/manifest?X-Plex-Http-Pipeline=infinite' for writing
Sep 30 21:24:07 kent.thenursery.josc sh[15594]: plex-transcoder    | [tcp @ 0x7f3e90c80e80] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 21:24:07 kent.thenursery.josc sh[15594]: plex-transcoder    | [tcp @ 0x7f3e90c80e80] Successfully connected to 10.11.12.13 port 32400
Sep 30 21:24:07 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e90181d40] Statistics: 0 seeks, 1 writeouts
Sep 30 21:24:07 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'chunk-stream0-00002.m4s.tmp' for writing
Sep 30 21:24:07 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'chunk-stream1-00002.m4s.tmp' for writing
Sep 30 21:24:08 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e91003fc0] Statistics: 0 seeks, 10 writeouts
Sep 30 21:24:08 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Representation 0 media segment 3 written to: chunk-stream0-00002.m4s
Sep 30 21:24:08 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e91004240] Statistics: 0 seeks, 1 writeouts
Sep 30 21:24:08 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Representation 1 media segment 3 written to: chunk-stream1-00002.m4s
Sep 30 21:24:08 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'http://10.11.12.13:32400/video/:/transcode/session/o9kp1hsky6b7lveao46qpb4b/5742c0b5-7b4a-49ac-b92d-6944bea6947e/manifest?X-Plex-Http-Pipeline=infinite' for writing
Sep 30 21:24:08 kent.thenursery.josc sh[15594]: plex-transcoder    | [tcp @ 0x7f3e90c80580] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 21:24:08 kent.thenursery.josc sh[15594]: plex-transcoder    | [tcp @ 0x7f3e90c80580] Successfully connected to 10.11.12.13 port 32400
Sep 30 21:24:08 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e90181ac0] Statistics: 0 seeks, 1 writeouts
Sep 30 21:24:08 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'chunk-stream0-00003.m4s.tmp' for writing
Sep 30 21:24:08 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'chunk-stream1-00003.m4s.tmp' for writing
Sep 30 21:24:09 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e91003fc0] Statistics: 0 seeks, 9 writeouts
Sep 30 21:24:09 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Representation 0 media segment 4 written to: chunk-stream0-00003.m4s
Sep 30 21:24:09 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e91004240] Statistics: 0 seeks, 1 writeouts
Sep 30 21:24:09 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Representation 1 media segment 4 written to: chunk-stream1-00003.m4s
Sep 30 21:24:09 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'http://10.11.12.13:32400/video/:/transcode/session/o9kp1hsky6b7lveao46qpb4b/5742c0b5-7b4a-49ac-b92d-6944bea6947e/manifest?X-Plex-Http-Pipeline=infinite' for writing
Sep 30 21:24:09 kent.thenursery.josc sh[15594]: plex-transcoder    | [tcp @ 0x7f3e90c80a00] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 21:24:09 kent.thenursery.josc sh[15594]: plex-transcoder    | [tcp @ 0x7f3e90c80a00] Successfully connected to 10.11.12.13 port 32400
Sep 30 21:24:09 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e90181700] Statistics: 0 seeks, 1 writeouts
Sep 30 21:24:09 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'chunk-stream0-00004.m4s.tmp' for writing
Sep 30 21:24:09 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'chunk-stream1-00004.m4s.tmp' for writing
Sep 30 21:24:11 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e90181d40] Statistics: 0 seeks, 9 writeouts
Sep 30 21:24:11 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Representation 0 media segment 5 written to: chunk-stream0-00004.m4s
Sep 30 21:24:11 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e91003fc0] Statistics: 0 seeks, 1 writeouts
Sep 30 21:24:11 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Representation 1 media segment 5 written to: chunk-stream1-00004.m4s
Sep 30 21:24:11 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'http://10.11.12.13:32400/video/:/transcode/session/o9kp1hsky6b7lveao46qpb4b/5742c0b5-7b4a-49ac-b92d-6944bea6947e/manifest?X-Plex-Http-Pipeline=infinite' for writing
Sep 30 21:24:11 kent.thenursery.josc sh[15594]: plex-transcoder    | [tcp @ 0x7f3e90c80c40] Starting connection attempt to 10.11.12.13 port 32400
Sep 30 21:24:11 kent.thenursery.josc sh[15594]: plex-transcoder    | [tcp @ 0x7f3e90c80c40] Successfully connected to 10.11.12.13 port 32400
Sep 30 21:24:11 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e91004100] Statistics: 0 seeks, 1 writeouts
Sep 30 21:24:11 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'chunk-stream0-00005.m4s.tmp' for writing
Sep 30 21:24:11 kent.thenursery.josc sh[15594]: plex-transcoder    | [dash @ 0x7f3e9d5b0040] Opening 'chunk-stream1-00005.m4s.tmp' for writing
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | Killing child process for task 8c87284c-3394-4dd2-b876-b499eb328f16
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | Removing process from taskMap
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e91004380] Statistics: 0 seeks, 5 writeouts
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3e9520bd00] Statistics: 0 seeks, 0 writeouts
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | frame=  327 fps= 44 q=-1.0 Lsize=N/A time=00:00:13.95 bitrate=N/A speed=1.88x
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | video:9890kB audio:410kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | Input file #0 (/media/movies/Kung Pow- Enter the Fist (2002)/Kung.Pow.Enter.The.Fist.2002.1080p.WEB-DL.DD5.1.H264-FGT.mkv):
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Input stream #0:0 (video): 332 packets read (7288406 bytes); 328 frames decoded;
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Input stream #0:1 (audio): 436 packets read (669696 bytes); 436 frames decoded (669696 samples);
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Input stream #0:2 (subtitle): 0 packets read (0 bytes);
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Input stream #0:3 (subtitle): 0 packets read (0 bytes);
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Input stream #0:4 (video): 1 packets read (5037 bytes);
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Input stream #0:5 (video): 1 packets read (8562 bytes);
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Input stream #0:6 (video): 1 packets read (23754 bytes);
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Input stream #0:7 (video): 1 packets read (24552 bytes);
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Total: 772 packets (8020007 bytes) demuxed
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | Output file #0 (dash):
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Output stream #0:0 (video): 327 frames encoded; 327 packets muxed (10126981 bytes);
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Output stream #0:1 (audio): 654 frames encoded (669696 samples); 655 packets muxed (419951 bytes);
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    |   Total: 982 packets (10546932 bytes) muxed
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] frame I:8     Avg QP:11.39  size: 98457
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] frame P:133   Avg QP:15.63  size: 46691
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] frame B:186   Avg QP:16.43  size: 16821
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] consecutive B-frames:  9.2% 42.8%  6.4% 41.6%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] mb I  I16..4: 36.4% 37.7% 25.9%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] mb P  I16..4: 13.7% 30.1%  3.8%  P16..4: 24.9% 12.9%  6.8%  0.0%  0.0%    skip: 7.7%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] mb B  I16..4:  4.4%  8.4%  0.3%  B16..8: 26.5%  8.8%  1.0%  direct:10.1%  skip:40.5%  L0:35.8% L1:47.4% BI:16.8%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] 8x8 transform intra:61.3% inter:42.4%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] coded y,uvDC,uvAC intra: 71.0% 61.5% 20.7% inter: 14.3% 17.0% 0.5%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] i16 v,h,dc,p: 26% 17% 38% 18%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] i8 v,h,dc,ddl,ddr,vr,hd,vl,hu: 16% 19% 34%  6%  5%  4%  5%  4%  6%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] i4 v,h,dc,ddl,ddr,vr,hd,vl,hu: 20% 25% 19%  8%  7%  5%  6%  5%  6%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] i8c dc,h,v,p: 50% 25% 20%  5%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] Weighted P-Frames: Y:0.0% UV:0.0%
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [libx264 @ 0x7f3e9d5bbb40] kb/s:5939.74
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [aac @ 0x7f3e9d5ae940] Qavg: 5301.975
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | [AVIOContext @ 0x7f3ea487f740] Statistics: 8062042 bytes read, 0 seeks
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | Exiting normally, received signal 15.
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | Completed transcode
Sep 30 21:24:12 kent.thenursery.josc sh[15594]: plex-transcoder    | Removing process from taskMap
```

nvidia-smi output:

```
Every 0.5s: nvidia-smi                                                                                                                            kent.thenursery.josc: Thu Sep 30 21:11:48 2021

Thu Sep 30 21:11:48 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.74	  Driver Version: 470.74       CUDA Version: 11.4     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA GeForce ...  Off  | 00000000:13:00.0 Off |                  N/A |
|  0%   63C    P2    30W / 120W |    231MiB /  6078MiB |      4%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A     25730      C   ...diaserver/Plex Transcoder      229MiB |
+-----------------------------------------------------------------------------+
```