### PR TITLE
EAE workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ The image extends the [LinuxServer Plex](https://hub.docker.com/r/linuxserver/pl
 | :----: | --- |
 | `ORCHESTRATOR_URL` | The url where the orchestrator service can be reached (ex: http://plex-orchestrator:3500) |
 | `PMS_IP` | IP pointing at the Plex instance (can be the cluster IP) |
+| `TRANSCODE_EAE_LOCALLY` | Force media which requires EasyAudioEncoder to transcode locally |
 | `TRANSCODE_OPERATING_MODE` | "local" => only local transcoding (no workers), "remote" => only remote workers transcoding, "both" (default) => Remote first, local if it fails |
 | `TRANSCODER_VERBOSE` | "0" (default) => info level, "1" => debug logging |
 

--- a/pms/app/transcoder.js
+++ b/pms/app/transcoder.js
@@ -9,6 +9,7 @@ const TRANSCODER_VERBOSE = process.env.TRANSCODER_VERBOSE || '0'
 // remote
 // both
 const TRANSCODE_OPERATING_MODE = process.env.TRANSCODE_OPERATING_MODE || 'both'
+const TRANSCODE_EAE_LOCALLY = process.env.TRANSCODE_EAE_LOCALLY || false
 
 const { spawn } = require('child_process');
 var ON_DEATH = require('death')({debug: true})
@@ -16,6 +17,9 @@ var ON_DEATH = require('death')({debug: true})
 var jobPoster = require('./jobPoster')
 
 if (TRANSCODE_OPERATING_MODE == 'local') {
+    transcodeLocally(process.cwd(), process.argv.slice(2), process.env)
+} else if (TRANSCODE_EAE_LOCALLY && process.argv.slice(2).filter(s => s.includes('eae_prefix')).length > 0) {
+    console.log('EasyAudioEncoder used, forcing local transcode')
     transcodeLocally(process.cwd(), process.argv.slice(2), process.env)
 } else {
     function setValueOf(arr, key, newValue) {


### PR DESCRIPTION
This PR adds an env variable to force EAE transcodes to be performed locally. 

This fixes the `EAE timeout!` error as worker nodes do not spawn Plex EAE Service.

Error:

```
[0x7f3a3abfa700] ERROR - [Transcoder] [ac3_eae @ 0x2fd4f40] EAE timeout! EAE not running, or wrong folder? Could not read '/tmp/pms-df2bb8fb-531b-4d33-9822-f24996fca71b/EasyAudioEncoder/Convert to WAV (to 8ch or less)/ynqwgibcfo6byomw1w226ct1_27313-1-2.wav'
```

`ps ax` from plex container:

```
# ps ax
    PID TTY      STAT   TIME COMMAND
      1 ?        Ss     0:00 s6-svscan -t0 /var/run/s6/services
     35 ?        S      0:00 s6-supervise s6-fdholderd
    710 ?        S      0:00 s6-supervise plex
    714 ?        Ssl    0:07 /usr/lib/plexmediaserver/Plex Media Server
    733 pts/0    Ss     0:00 /bin/sh
    765 ?        SNl    0:02 Plex Plug-in [com.plexapp.system] /usr/lib/plexmediaserver/Resources/Plug-ins-757abe6b4/Framework.bundle/Contents/Resources/Versions/2/Python/bootstrap.py --server-version 1.24.3.5033-757abe6b4 /usr/
    814 ?        Sl     0:00 /usr/lib/plexmediaserver/Plex Tuner Service /usr/lib/plexmediaserver/Resources/Tuner/Private /usr/lib/plexmediaserver/Resources/Tuner/Shared 1.24.3.5033-757abe6b4 32600
    839 ?        Sl     0:02 Plex Plug-in [com.plexapp.agents.imdb] /usr/lib/plexmediaserver/Resources/Plug-ins-757abe6b4/Framework.bundle/Contents/Resources/Versions/2/Python/bootstrap.py --server-version 1.24.3.5033-757abe6b4
   1190 pts/0    S+     0:00 vi /app/transcoder.js
   1202 ?        S      0:00 Plex EAE Service
   1404 pts/1    Ss     0:00 /bin/sh
   1411 pts/1    R+     0:00 ps ax
```

`ps ax` from worker node:

```
# ps ax
    PID TTY      STAT   TIME COMMAND
      1 ?        Ss     0:00 s6-svscan -t0 /var/run/s6/services
     36 ?        S      0:00 s6-supervise s6-fdholderd
    832 ?        S      0:00 s6-supervise plex
   2842 pts/0    Ss+    0:00 /bin/sh
   3081 pts/1    Ss+    0:00 /bin/sh
   3099 ?        Ss     0:00 /bin/bash /usr/lib/plexmediaserver/Plex Media Server
   3117 ?        Sl     0:02 node worker.js
   3125 pts/2    Ss     0:00 /bin/sh
   3292 pts/2    R+     0:00 ps ax
```