### PR TITLE
Transcode specific codecs locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,10 +278,10 @@ The image extends the [LinuxServer Plex](https://hub.docker.com/r/linuxserver/pl
 | :----: | --- |
 | `ORCHESTRATOR_URL` | The url where the orchestrator service can be reached (ex: http://plex-orchestrator:3500) |
 | `PMS_IP` | IP pointing at the Plex instance (can be the cluster IP) |
+| `TRANSCODE_CODECS_LOCALLY` | Comma separated list of codecs to transcode locally (ex: hevc, av1, mpeg4) |
 | `TRANSCODE_EAE_LOCALLY` | Force media which requires EasyAudioEncoder to transcode locally |
 | `TRANSCODE_OPERATING_MODE` | "local" => only local transcoding (no workers), "remote" => only remote workers transcoding, "both" (default) => Remote first, local if it fails |
 | `TRANSCODER_VERBOSE` | "0" (default) => info level, "1" => debug logging |
-| `IGNORED_CODECS` | Comma separated list of codecs that will always transcode locally (ex: hevc, av1, mpeg4) |
 
 ### Orchestrator
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ The image extends the [LinuxServer Plex](https://hub.docker.com/r/linuxserver/pl
 | `TRANSCODE_EAE_LOCALLY` | Force media which requires EasyAudioEncoder to transcode locally |
 | `TRANSCODE_OPERATING_MODE` | "local" => only local transcoding (no workers), "remote" => only remote workers transcoding, "both" (default) => Remote first, local if it fails |
 | `TRANSCODER_VERBOSE` | "0" (default) => info level, "1" => debug logging |
+| `IGNORED_CODECS` | Comma separated list of codecs that will always transcode locally |
 
 ### Orchestrator
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ The image extends the [LinuxServer Plex](https://hub.docker.com/r/linuxserver/pl
 | `TRANSCODE_EAE_LOCALLY` | Force media which requires EasyAudioEncoder to transcode locally |
 | `TRANSCODE_OPERATING_MODE` | "local" => only local transcoding (no workers), "remote" => only remote workers transcoding, "both" (default) => Remote first, local if it fails |
 | `TRANSCODER_VERBOSE` | "0" (default) => info level, "1" => debug logging |
-| `IGNORED_CODECS` | Comma separated list of codecs that will always transcode locally |
+| `IGNORED_CODECS` | Comma separated list of codecs that will always transcode locally (ex: hevc, av1, mpeg4) |
 
 ### Orchestrator
 

--- a/pms/app/transcoder.js
+++ b/pms/app/transcoder.js
@@ -101,11 +101,11 @@ function transcodeLocally(cwd, args, env) {
 
 function extractPrimaryCodec(argList) {
     let indexPrimaryCodec = argList.findIndex(s => s == '-codec:0') + 1
-    return (indexPrimaryCodec != 0 && argList.length >= indexPrimaryCodec) ? argList[indexPrimaryCodec] : ''
+    return (indexPrimaryCodec != 0 && argList.length >= indexPrimaryCodec) ? argList[indexPrimaryCodec].toLowerCase() : ''
 }
 
 function codecIgnored(codecString) {
-    return (codecString == '') ? false : IGNORED_CODECS.split(",").map(item=>item.trim()).includes(codecString)
+    return (codecString == '') ? false : IGNORED_CODECS.toLowerCase().split(",").map(item=>item.trim()).includes(codecString)
 }
 
 ON_DEATH( (signal, err) => {

--- a/pms/app/transcoder.js
+++ b/pms/app/transcoder.js
@@ -10,6 +10,8 @@ const TRANSCODER_VERBOSE = process.env.TRANSCODER_VERBOSE || '0'
 // both
 const TRANSCODE_OPERATING_MODE = process.env.TRANSCODE_OPERATING_MODE || 'both'
 const TRANSCODE_EAE_LOCALLY = process.env.TRANSCODE_EAE_LOCALLY || false
+// comma separated list of ignored codecs:
+const IGNORED_CODECS = process.env.IGNORED_CODECS || ''
 
 const { spawn } = require('child_process');
 var ON_DEATH = require('death')({debug: true})
@@ -21,6 +23,15 @@ if (TRANSCODE_OPERATING_MODE == 'local') {
 } else if (TRANSCODE_EAE_LOCALLY && process.argv.slice(2).filter(s => s.includes('eae_prefix')).length > 0) {
     console.log('EasyAudioEncoder used, forcing local transcode')
     transcodeLocally(process.cwd(), process.argv.slice(2), process.env)
+} else if (IGNORED_CODECS.length > 0) {
+    let indexPrimaryCodec = process.argv.slice(2).findIndex(s => s == '-codec:0')
+    if (indexPrimaryCodec != -1 && process.argv.slice(2).length > indexPrimaryCodec + 1) {
+        let codecPrimary = process.argv.slice(2)[indexPrimaryCodec + 1]
+        if (IGNORED_CODECS.split(",").map(item=>item.trim()).includes(codecPrimary)) {
+            console.log('Primary codec (' + codecPrimary + ') on ignore list, forcing local transcode')
+            transcodeLocally(process.cwd(), process.argv.slice(2), process.env)
+        }
+    }
 } else {
     function setValueOf(arr, key, newValue) {
         let i = arr.indexOf(key)

--- a/pms/app/transcoder.js
+++ b/pms/app/transcoder.js
@@ -23,15 +23,9 @@ if (TRANSCODE_OPERATING_MODE == 'local') {
 } else if (TRANSCODE_EAE_LOCALLY && process.argv.slice(2).filter(s => s.includes('eae_prefix')).length > 0) {
     console.log('EasyAudioEncoder used, forcing local transcode')
     transcodeLocally(process.cwd(), process.argv.slice(2), process.env)
-} else if (IGNORED_CODECS.length > 0) {
-    let indexPrimaryCodec = process.argv.slice(2).findIndex(s => s == '-codec:0')
-    if (indexPrimaryCodec != -1 && process.argv.slice(2).length > indexPrimaryCodec + 1) {
-        let codecPrimary = process.argv.slice(2)[indexPrimaryCodec + 1]
-        if (IGNORED_CODECS.split(",").map(item=>item.trim()).includes(codecPrimary)) {
-            console.log('Primary codec (' + codecPrimary + ') on ignore list, forcing local transcode')
-            transcodeLocally(process.cwd(), process.argv.slice(2), process.env)
-        }
-    }
+} else if (IGNORED_CODECS && codecIgnored(extractPrimaryCodec(process.argv.slice(2)))) {
+    console.log('Primary codec (' + extractPrimaryCodec(process.argv.slice(2)) + ') on ignore list, forcing local transcode')
+    transcodeLocally(process.cwd(), process.argv.slice(2), process.env)
 } else {
     function setValueOf(arr, key, newValue) {
         let i = arr.indexOf(key)
@@ -103,6 +97,15 @@ function transcodeLocally(cwd, args, env) {
         console.log('Completed local transcode');
         process.exit(withErrors);
     });
+}
+
+function extractPrimaryCodec(argList) {
+    let indexPrimaryCodec = argList.findIndex(s => s == '-codec:0') + 1
+    return (indexPrimaryCodec != 0 && argList.length >= indexPrimaryCodec) ? argList[indexPrimaryCodec] : ''
+}
+
+function codecIgnored(codecString) {
+    return (codecString == '') ? false : IGNORED_CODECS.split(",").map(item=>item.trim()).includes(codecString)
 }
 
 ON_DEATH( (signal, err) => {

--- a/pms/app/transcoder.js
+++ b/pms/app/transcoder.js
@@ -10,8 +10,8 @@ const TRANSCODER_VERBOSE = process.env.TRANSCODER_VERBOSE || '0'
 // both
 const TRANSCODE_OPERATING_MODE = process.env.TRANSCODE_OPERATING_MODE || 'both'
 const TRANSCODE_EAE_LOCALLY = process.env.TRANSCODE_EAE_LOCALLY || false
-// comma separated list of ignored codecs:
-const IGNORED_CODECS = process.env.IGNORED_CODECS || ''
+// comma separated list of codecs to transcode locally:
+const TRANSCODE_CODECS_LOCALLY = process.env.TRANSCODE_CODECS_LOCALLY || ''
 
 const { spawn } = require('child_process');
 var ON_DEATH = require('death')({debug: true})
@@ -23,7 +23,7 @@ if (TRANSCODE_OPERATING_MODE == 'local') {
 } else if (TRANSCODE_EAE_LOCALLY && process.argv.slice(2).filter(s => s.includes('eae_prefix')).length > 0) {
     console.log('EasyAudioEncoder used, forcing local transcode')
     transcodeLocally(process.cwd(), process.argv.slice(2), process.env)
-} else if (IGNORED_CODECS && codecIgnored(extractPrimaryCodec(process.argv.slice(2)))) {
+} else if (TRANSCODE_CODECS_LOCALLY && codecIgnored(extractPrimaryCodec(process.argv.slice(2)))) {
     console.log('Primary codec (' + extractPrimaryCodec(process.argv.slice(2)) + ') on ignore list, forcing local transcode')
     transcodeLocally(process.cwd(), process.argv.slice(2), process.env)
 } else {
@@ -105,7 +105,7 @@ function extractPrimaryCodec(argList) {
 }
 
 function codecIgnored(codecString) {
-    return (codecString == '') ? false : IGNORED_CODECS.toLowerCase().split(",").map(item=>item.trim()).includes(codecString)
+    return (codecString == '') ? false : TRANSCODE_CODECS_LOCALLY.toLowerCase().split(",").map(item=>item.trim()).includes(codecString)
 }
 
 ON_DEATH( (signal, err) => {


### PR DESCRIPTION
Adds new env var to force specific codecs to transcode locally rather than on worker nodes.

This is useful if your local PMS supports hardware transcoding a wider range of codecs than your worker nodes.

In my kubernetes cluster I have 10 workers capable of h264 decoding and encoding on the gpu using VAAPI. They are not capable of using the gpu for decoding some hevc content. The transcode will fail with PMS console error:

`[Transcoder] [hevc @ 0x7fa8d9381940] Failed setup for format vaapi_vld: hwaccel initialisation returned error.`

With this patch I can set the local PMS to transcode hevc content while the worker nodes will continue to transcode h264, mpeg4, etc.  Specify codecs with `TRANSCODE_CODECS_LOCALLY` env var with a comma-separated list using ffmpeg naming convention, see `ffmpeg -codecs` for a full list. 

This compares only the primary codec in each stream against your provided list of codecs.  With videos this should be the video track codec and with music the audio track codec.  It doesn't select by audio codec on videos.