### PR TITLE
Add support for "Required" Secure Connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ The image extends the [LinuxServer Plex](https://hub.docker.com/r/linuxserver/pl
 | `TRANSCODE_EAE_LOCALLY` | Force media which requires EasyAudioEncoder to transcode locally |
 | `TRANSCODE_OPERATING_MODE` | "local" => only local transcoding (no workers), "remote" => only remote workers transcoding, "both" (default) => Remote first, local if it fails |
 | `TRANSCODER_VERBOSE` | "0" (default) => info level, "1" => debug logging |
+| `FORCE_HTTPS` | "0" (Default) uses Plex's default http callback, "1" forces HTTPS to be used.<br>**IMPORTANT:** You must set this to "1" if you have set "Secure Connections" in Plex to "Required". |
 
 ### Orchestrator
 

--- a/pms/app/transcoder.js
+++ b/pms/app/transcoder.js
@@ -10,6 +10,7 @@ const TRANSCODER_VERBOSE = process.env.TRANSCODER_VERBOSE || '0'
 // both
 const TRANSCODE_OPERATING_MODE = process.env.TRANSCODE_OPERATING_MODE || 'both'
 const TRANSCODE_EAE_LOCALLY = process.env.TRANSCODE_EAE_LOCALLY || false
+const FORCE_HTTPS = process.env.FORCE_HTTPS || "0"
 
 const { spawn } = require('child_process');
 var ON_DEATH = require('death')({debug: true})
@@ -29,9 +30,16 @@ if (TRANSCODE_OPERATING_MODE == 'local') {
         }
     }
 
+    let networkProtocol = "http";
+    if (FORCE_HTTPS == '1') {
+        console.log('Forcing HTTPS in progress callback');
+        networkProtocol = "https";
+    }
+
     let newArgs = process.argv.slice(2).map((v) => {
         return v
-            .replace('127.0.0.1:', `${PMS_IP}:`)
+            .replace('http://127.0.0.1:', `${networkProtocol}://${PMS_IP}:`)
+            .replace('https://127.0.0.1:', `https://${PMS_IP}:`)
             .replace('aac_lc', 'aac');  // workaround for error -> Unknown decoder 'aac_lc'
     })
 


### PR DESCRIPTION
Added support for Secure Connections, when set to "Required".
To use it set the FORCE_HTTPS environment variable to "1".