### PR TITLE
Updated Nginx configuration to account for live tv

### DIFF
--- a/pms/docker-mod/root/etc/nginx/sites-available/forward-proxy.conf
+++ b/pms/docker-mod/root/etc/nginx/sites-available/forward-proxy.conf
@@ -8,4 +8,13 @@ server {
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
     }
+    location /livetv/ { 
+        proxy_pass http://127.0.0.1:_PMS_PORT;
+        proxy_request_buffering off;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
+
 }


### PR DESCRIPTION
When trying to use remove transcoders for live tv, I was received the following error:

`tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | http://plex:32499/livetv/sessions/d3788a72-ee4f-483a-a2da-eabaf961da3a/15oox7pclqpg67i02iwbrgvx/index.m3u8?offset=26.760067&X-Plex-Incomplete-Segments=1&X-Plex-Token=xAdQkS6_Y_KS-p22eSxn: Server returned 404 Not Found`

Followed by a success:

`tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [stream_segment,ssegment @ 0x7f6a1a9e5040] Opening 'http://plex:32499/video/:/transcode/session/d3788a72-ee4f-483a-a2da-eabaf961da3a/61607cc2-70b7-4ee3-b85e-6bcabff5f8d8/manifest?X-Plex-Http-Pipeline=infinite' for writing`

I went into the container and added this to listen on /livetv and the remove transcoding is now working
```
When trying to use remove transcoders for live tv, I was received the following error:

`tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | http://plex:32499/livetv/sessions/d3788a72-ee4f-483a-a2da-eabaf961da3a/15oox7pclqpg67i02iwbrgvx/index.m3u8?offset=26.760067&X-Plex-Incomplete-Segments=1&X-Plex-Token=xAdQkS6_Y_KS-p22eSxn: Server returned 404 Not Found`

Followed by a success to /video:

`tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [stream_segment,ssegment @ 0x7f6a1a9e5040] Opening 'http://plex:32499/video/:/transcode/session/d3788a72-ee4f-483a-a2da-eabaf961da3a/61607cc2-70b7-4ee3-b85e-6bcabff5f8d8/manifest?X-Plex-Http-Pipeline=infinite' for writing`

I went into the container and added this to listen on /livetv and the remove transcoding is now working
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [hls @ 0x7ffbf5fe7040] HLS request for url 'http://plex:32499/livetv/sessions/ba4cbb2e-5175-4a4c-8d30-b280e0e2ee8a/718c7dc67b856caa-com-plexapp-android/00000.ts?X-Plex-Incomplete-Segments=1', offset 0, playlist 0
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [hls @ 0x7ffbf5fe7040] Opening 'http://plex:32499/livetv/sessions/ba4cbb2e-5175-4a4c-8d30-b280e0e2ee8a/718c7dc67b856caa-com-plexapp-android/00000.ts?X-Plex-Incomplete-Segments=1' for reading
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [tcp @ 0x7ffbf5fe7480] Starting connection attempt to 10.10.10.125 port 32499
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [tcp @ 0x7ffbf5fe7480] Successfully connected to 10.10.10.125 port 32499
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [hls @ 0x7ffbf5fe7040] HLS request for url 'http://plex:32499/livetv/sessions/ba4cbb2e-5175-4a4c-8d30-b280e0e2ee8a/718c7dc67b856caa-com-plexapp-android/00001.ts?X-Plex-Incomplete-Segments=1', offset 0, playlist 0
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [hls @ 0x7ffbf5fe7040] Opening 'http://plex:32499/livetv/sessions/ba4cbb2e-5175-4a4c-8d30-b280e0e2ee8a/718c7dc67b856caa-com-plexapp-android/00001.ts?X-Plex-Incomplete-Segments=1' for reading
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [tcp @ 0x7ffbf7399e80] Starting connection attempt to 10.10.10.125 port 32499
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [tcp @ 0x7ffbf7399e80] Successfully connected to 10.10.10.125 port 32499
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [NULL @ 0x7ffbf5b665c0] non-existing SPS 0 referenced in buffering period
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [h264 @ 0x7ffbf28b8600] Reinit context to 1280x720, pix_fmt: yuv420p
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | Input #0, hls, from 'http://plex:32499/livetv/sessions/ba4cbb2e-5175-4a4c-8d30-b280e0e2ee8a/718c7dc67b856caa-com-plexapp-android/index.m3u8?offset=0.000000&X-Plex-Incomplete-Segments=1&X-Plex-Token=WsRSMmmcpJv4E6qjzowT':
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Metadata:
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |     creation_time   : 2023-04-11T14:34:59.053309Z
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Duration: N/A, start: 10.009544, bitrate: N/A
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Program 0 
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |     Metadata:
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |       variant_bitrate : 0
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Stream #0:0: Video: h264 (High), 1 reference frame ([27][0][0][0] / 0x001B), yuv420p(tv, progressive, left), 1280x720 [SAR 1:1 DAR 16:9], Closed Captions, 59.94 fps, 59.94 tbr, 90k tbn
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |     Metadata:
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |       variant_bitrate : 0
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 44100 Hz, stereo, fltp, 96 kb/s
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |     Metadata:
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |       variant_bitrate : 0
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Stream #0:2: Audio: aac (LC) ([15][0][0][0] / 0x000F), 44100 Hz, stereo, fltp, 92 kb/s
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |     Metadata:
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |       variant_bitrate : 0
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [Parsed_scale_0 @ 0x7ffbf29c1680] w:480 h:270 flags:'' interl:0
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | Stream mapping:
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Stream #0:0 (h264) -> scale:default (graph 0)
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Stream #0:1 (aac) -> aresample:default (graph 1)
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   format:default (graph 0) -> Stream #0:0 (libx264)
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   aresample:default (graph 1) -> Stream #0:1 (libopus)
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | Press [q] to stop, [?] for help
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [h264 @ 0x7ffbef631940] Reinit context to 1280x720, pix_fmt: yuv420p
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [graph_1_in_0_1 @ 0x7ffbf72f4640] tb:1/44100 samplefmt:fltp samplerate:44100 chlayout:stereo
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [Parsed_aresample_0 @ 0x7ffbf73e5c40] ch:2 chl:stereo fmt:fltp r:44100Hz -> ch:2 chl:stereo fmt:flt r:48000Hz
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [Parsed_scale_0 @ 0x7ffbebada340] w:480 h:270 flags:'' interl:0
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [graph 0 input from stream 0:0 @ 0x7ffbebadb0c0] w:1280 h:720 pixfmt:yuv420p tb:1/90000 fr:60000/1001 sar:1/1
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [Parsed_scale_0 @ 0x7ffbebada340] w:1280 h:720 fmt:yuv420p sar:1/1 -> w:480 h:270 fmt:yuv420p sar:1/1 flags:0x0
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |     Last message repeated 3 times
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [libx264 @ 0x7ffbf0981680] using SAR=1/1
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [libx264 @ 0x7ffbf0981680] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [libx264 @ 0x7ffbf0981680] profile Main, level 5.1, 4:2:0, 8-bit
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [stream_segment,ssegment @ 0x7ffbf3f973c0] Selected stream id:0 type:video
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [stream_segment,ssegment @ 0x7ffbf3f973c0] Opening 'media-00000.ts' for writing
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [mpegts @ 0x7ffbef54f380] service 1 using PCR in pid=256, pcr_period=83ms
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [mpegts @ 0x7ffbef54f380] muxrate VBR, sdt every 500 ms, pat/pmt every 100 ms
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | Output #0, stream_segment,ssegment, to 'media-%05d.ts':
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Metadata:
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |     encoder         : Lavf59.20.101
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Stream #0:0: Video: h264, 1 reference frame, yuv420p(tv, progressive, left), 480x270 (0x0) [SAR 1:1 DAR 16:9], q=2-31, 59.94 fps, 90k tbn
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |     Metadata:
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |       encoder         : Lavc59.25.100 libx264
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |     Side data:
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |       cpb: bitrate max/min/avg: 553000/0/0 buffer size: 1106000 vbv_delay: N/A
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |   Stream #0:1: Audio: opus, 48000 Hz, stereo, flt, delay 312, 125 kb/s
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |     Metadata:
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    |       encoder         : Lavc59.25.100 libopus
tv_tv-worker-node.1.ry9ffann85wj@gadget-worker-node    | [stream_segment,ssegment @ 0x7ffbf3f973c0] Opening 'http://plex:32499/video/:/transcode/session/718c7dc67b856caa-com-plexapp-android/125e0b86-7e0b-4022-bca6-8417586db7a3/manifest?X-Plex-Http-Pipeline=infinite' for writing
```

I saw a previous error found here: https://github.com/pabloromeo/clusterplex/issues/32

I tested this feature with xteve and received the same error as above.  Plex changed the way LiveTV works between that issue and today and I believe this is why /livetv is necessary.  This has been tested and works with xteve.  Please let me know if you need anything further from me.

Thanks,
Austin