### PR TITLE
Support dual stack relay

### DIFF
--- a/pms/docker-mod/root/etc/nginx/sites-available/forward-proxy.conf
+++ b/pms/docker-mod/root/etc/nginx/sites-available/forward-proxy.conf
@@ -1,5 +1,5 @@
 server {
-    listen _LOCAL_RELAY_PORT;
+    listen [::]:_LOCAL_RELAY_PORT ipv6only=off;
     location /video/:/transcode/session/ { 
         proxy_pass http://127.0.0.1:_PMS_PORT;
         proxy_request_buffering off;


### PR DESCRIPTION
This PR supports dual stack on the relay, at the moment ipv6 connections are refused:

```
[tcp @ 0x7f13b2d8d940] Starting connection attempt to 2000:f90:1234:172::4fb7 port 32499
[tcp @ 0x7f13b2d8d940] Connection attempt to 2000:f90:1234:172::4fb7 port 32499 failed: Connection refused
[tcp @ 0x7f13b2d8d940] Starting connection attempt to 172.22.212.174 port 32499
[tcp @ 0x7f13b2d8d940] Successfully connected to 172.22.212.174 port 32499
[AVIOContext @ 0x7f13c3950ac0] Statistics: 2115 bytes written, 0 seeks, 1 writeouts
```

With the change you can connect on both ipv4 and ipv6:

```
[tcp @ 0x7f139dd03a40] Starting connection attempt to 2000:f90:1234:172::4fb7 port 32499
[tcp @ 0x7f139dd03a40] Successfully connected to 2000:f90:1234:172::4fb7 port 32499
[AVIOContext @ 0x7f13c3950780] Statistics: 2132 bytes written, 0 seeks, 1 writeouts
```