### PR TITLE
ON_DEATH process.exit with int exit code

### DIFF
--- a/orchestrator/server.js
+++ b/orchestrator/server.js
@@ -20,5 +20,20 @@ server.listen(LISTENING_PORT, () => {
 ON_DEATH((signal, err) => {
   console.log("ON_DEATH signal detected");
   console.error(err);
-  process.exit(signal);
+	let exitCode = 0;
+	switch (signal) {
+		case "SIGINT":
+			exitCode = 130;
+			break;
+		case "SIGQUIT":
+			exitCode = 131;
+			break;
+		case "SIGTERM":
+			exitCode = 143;
+			break;
+		default:
+			exitCode = 1;
+			break;
+	}
+	process.exit(exitCode);
 });

--- a/pms/app/transcoder.js
+++ b/pms/app/transcoder.js
@@ -165,5 +165,20 @@ ON_DEATH((signal, err) => {
 		console.log("Killing child transcoder");
 		child.kill();
 	}
-	process.exit(signal);
+	let exitCode = 0;
+	switch (signal) {
+		case "SIGINT":
+			exitCode = 130;
+			break;
+		case "SIGQUIT":
+			exitCode = 131;
+			break;
+		case "SIGTERM":
+			exitCode = 143;
+			break;
+		default:
+			exitCode = 1;
+			break;
+	}
+	process.exit(exitCode);
 });

--- a/worker/app/worker.js
+++ b/worker/app/worker.js
@@ -245,7 +245,22 @@ ON_DEATH((signal, err) => {
 	console.log("ON_DEATH signal detected");
 	console.error(err);
 	deleteEAE_PID();
-	process.exit(signal);
+	let exitCode = 0;
+	switch (signal) {
+		case "SIGINT":
+			exitCode = 130;
+			break;
+		case "SIGQUIT":
+			exitCode = 131;
+			break;
+		case "SIGTERM":
+			exitCode = 143;
+			break;
+		default:
+			exitCode = 1;
+			break;
+	}
+	process.exit(exitCode);
 });
 
 function deleteEAE_PID() {


### PR DESCRIPTION
Currently, the code is liable to throw the following error:

```
Sending SIGTERM to the child process
Trapped SIGTERM
ON_DEATH signal detected
SIGTERM
node:internal/validators:95
      throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received type string ('SIGTERM')
    at process.set [as exitCode] (node:internal/bootstrap/node:123:9)
    at process.exit (node:internal/process/per_thread:188:24)
    at /app/transcoder.js:168:10
    at process.handler (/app/node_modules/death/lib/death.js:22:20)
    at process.emit (node:events:514:28) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

This change maps the string signal code passed from the `death` package to an int exit code which is then passed to `process.exit`.