### PR TITLE
Add config to enable http on pms service

### DIFF
--- a/charts/clusterplex/templates/pms.yaml
+++ b/charts/clusterplex/templates/pms.yaml
@@ -75,9 +75,22 @@ service:
     labels:
       {{- toYaml .Values.pms.serviceConfig.labels | nindent 6 }}
     ports:
+    {{ if .Values.pms.serviceConfig.enableHttpPorts }}
+      http:
+        enabled: true
+        primary: false
+        port: 80
+        targetPort: 32400
+      https:
+        enabled: true
+        primary: false
+        port: 443
+        targetPort: 32400
+    {{ else }}
       http:
         enabled: false
         primary: false
+    {{- end}}
       plex:
         enabled: true
         primary: true

--- a/charts/clusterplex/values.yaml
+++ b/charts/clusterplex/values.yaml
@@ -156,6 +156,9 @@ pms:
     # -- Provide additional labels which may be required.
     labels: {}
 
+    # -- Enable ports 80/443 on service
+    enableHttpPorts: false
+
   # -- Configure the ingress for plex here.
   # @default -- See below
   ingressConfig:


### PR DESCRIPTION
Adds a config option to `values.yaml` to let you enable the HTTP/HTTPS ports on the main PMS service. This is useful so you can just expose the PMS service as a `LoadBalancer` and let it service all external HTTPS traffic, which is really useful if you have HTTPS and custom domain configured inside of Plex.

```bash
kubectl -n media get service plex-pms
NAME       TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                                      AGE
plex-pms   LoadBalancer   10.101.77.235   192.168.0.100   80:32528/TCP,443:32058/TCP,32400:32094/TCP,32499:31481/TCP   11h
```
