### PR TITLE
Add sslSecret value for mounting custom certificate

### DIFF
--- a/charts/clusterplex/templates/pms.yaml
+++ b/charts/clusterplex/templates/pms.yaml
@@ -113,6 +113,13 @@ persistence:
     {{ if not .Values.global.sharedStorage.media.existingClaim }}
     existingClaim: {{ .Release.Name }}-media
     {{- end }}
+  {{ if .Values.pms.config.sslSecret }}
+  ssl:
+    enabled: true
+    type: secret
+    name: {{ .Values.pms.config.sslSecret }}
+    mountPath: /ssl
+  {{- end }}
 {{- range $key, $value := .Values.global.sharedStorage.additionalMediaVolumes -}}
   {{ $key | nindent 2}}:
     {{- toYaml $value | nindent 4 }}

--- a/charts/clusterplex/values.yaml
+++ b/charts/clusterplex/values.yaml
@@ -140,6 +140,10 @@ pms:
     # -- The IP address that plex is using. This is only utilized if you disable the localRelayEnabled option above.
     pmsIP: ""
 
+    # -- kubernetes secert for SSL certificate, should contain a pkcs12 (.p12) key for Plex to use
+    # Secret will be mounted at `/ssl`
+    sslSecret: ""
+
   # -- Configure the kubernetes service associated with the the PMS component
   # @default -- See below
   serviceConfig:


### PR DESCRIPTION
This adds a new secret mount that lets you load a pkcs12 keystrore to use with Plex.

It would allow you to create and manage a cert with something like [cert-manager](https://cert-manager.io/):

```yml
apiVersion: v1
kind: Secret
metadata:
  name: pkcs-secret
  namespace: media
type: Opaque
stringData:
  password: somePassword
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: cert-plex
  namespace: media
spec:
  secretName: cert-plex
  duration: 2160h
  renewBefore: 360h
  issuerRef:
    name: letsencrypt-prod
    kind: ClusterIssuer
  commonName: plex.example.com
  dnsNames:
  - plex.example.com
  keystores:
    pkcs12:
      create: true
      profile: Modern2023  # important as default profile will not work with Plex
      passwordSecretRef:
        name: pkcs-secret
        key: password
```

Then you can set `sslSecret` from above (`cert-plex`) and it will mount the keystore at `/ssl/keystore.p12` so you can then use the following Network settings:

```
Custom certificate location: /ssl/keystore.p12
Custom certificate encryption key: somePassword
Custom certificate domain: plex.example.com
Custom server access URLs: https://plex.example.com
```

Pairs well with my other PR: https://github.com/pabloromeo/clusterplex/pull/329