### PR TITLE
Update 92-install-dependencies

### DIFF
--- a/pms/docker-mod/_old_cont-init.d/92-install-dependencies
+++ b/pms/docker-mod/_old_cont-init.d/92-install-dependencies
@@ -8,7 +8,7 @@ else
     echo "**** apt-get update ****"
     apt-get update
     echo "**** install libatomic1, file, nginx ****"
-    apt-get install -y libatomic1 file nginx
+    apt-get install -o DPkg::Lock::Timeout=60 -y libatomic1 file nginx
     echo "**** install 'n' ****"
     curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n
     echo "**** install nodejs ****"


### PR DESCRIPTION
Added 60 second timeout to the dependency installs due to apt database being locked and nginx install failing on startup.