### PR TITLE
feat/add opt-in local Plex preview transcoding

### DIFF
--- a/charts/clusterplex/README.md
+++ b/charts/clusterplex/README.md
@@ -99,6 +99,7 @@ $ helm install clusterplex clusterplex/clusterplex
 | pms.config.port | int | `32400` | The port that Plex will listen on |
 | pms.config.relayPort | int | `32499` | The port that the relay service will listen on |
 | pms.config.transcodeOperatingMode | string | `"both"` | Set the transcode operating mode. Valid options are local (No workers), remote (only remote workers), both (default, remote first then local if remote fails). If you disable the worker then this will be set to local automatically as that is the only valid option for that confguration. |
+| pms.config.transcodePreviewsLocally | bool | `true` | Set this to true to force Plex video preview and chapter thumbnail generation to transcode locally. |
 | pms.config.transcoderVerbose | int | `1` | Set this to 1 if you want only info logging from the transcoder or 0 if you want debugging logs |
 | pms.config.version | string | `"docker"` | Set the version of Plex to use. Valid options are docker, latest, public, or a specific version. [[ref](https://github.com/linuxserver/docker-plex#application-setup)] |
 | pms.configVolume | object | See below | Configure the volume that stores all the Plex configuration and metadata |

--- a/charts/clusterplex/custom-values.yaml
+++ b/charts/clusterplex/custom-values.yaml
@@ -119,6 +119,9 @@ pms:
     # If you disable the worker then this will be set to local automatically as that is the only valid option for that confguration.
     transcodeOperatingMode: both
 
+    # -- Set this to true to force Plex video preview and chapter thumbnail generation to transcode locally.
+    transcodePreviewsLocally: true
+
     # -- Set the Plex claim token obtained from https://plex.tv/claim
     plexClaimToken:
 

--- a/charts/clusterplex/templates/pms.yaml
+++ b/charts/clusterplex/templates/pms.yaml
@@ -32,6 +32,7 @@ configMaps:
       {{ else }}
       TRANSCODE_OPERATING_MODE: 'local'
       {{- end }}
+      TRANSCODE_PREVIEWS_LOCALLY: '{{ ternary "true" "false" .Values.pms.config.transcodePreviewsLocally }}'
       {{ if .Values.pms.config.localRelayEnabled }}
       LOCAL_RELAY_ENABLED: '1'
       LOCAL_RELAY_PORT: '{{ .Values.pms.config.relayPort | default "32499" }}'

--- a/charts/clusterplex/values.yaml
+++ b/charts/clusterplex/values.yaml
@@ -119,6 +119,9 @@ pms:
     # If you disable the worker then this will be set to local automatically as that is the only valid option for that confguration.
     transcodeOperatingMode: both
 
+    # -- Set this to true to force Plex video preview and chapter thumbnail generation to transcode locally.
+    transcodePreviewsLocally: true
+
     # -- Set the Plex claim token obtained from https://plex.tv/claim
     plexClaimToken:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The image extends the [LinuxServer Plex](https://hub.docker.com/r/linuxserver/pl
 | `ORCHESTRATOR_URL` | The url where the orchestrator service can be reached (ex: http://plex-orchestrator:3500) |
 | `PMS_SERVICE` or `PMS_IP` | Referencing Plex by Service name is allowed if `LOCAL_RELAY_ENABLED` is `"1"` (which is the default). If you are not using Local Relay then specify `PLEX_IP`, which also requires you to add the workers subnets to `"List of IP addresses and networks that are allowed without auth"` |
 | `TRANSCODE_EAE_LOCALLY` | `"true"` or `"false"`. Force media which requires EasyAudioEncoder to transcode locally. Given that EAE is currently supported by the latest versions of ClusterPlex there's usually no reason to enable this. It will most likely be deprecated in the future. Default => `"false"`|
+| `TRANSCODE_PREVIEWS_LOCALLY` | `"true"` or `"false"`. Force Plex video preview/chapter thumbnail generation to transcode locally. Default => `"true"`|
 | `TRANSCODE_OPERATING_MODE` | `"local"` => only local transcoding (no workers)<br/>`"remote"` => only remote workers transcoding<br/>`"both"` (default) => Remote first, local if it fails |
 | `TRANSCODER_VERBOSE` | `"0"` (default) => info level, `"1"` => debug logging |
 | `FORCE_HTTPS` | `"0"` (Default) uses Plex's default http callback, `"1"` forces HTTPS to be used.<br>**IMPORTANT:** Turning this on is only required if you have BOTH disabled Local Relay and have `Secure Connetions` in Plex set to `Required`. |

--- a/pms/app/transcoder.js
+++ b/pms/app/transcoder.js
@@ -19,6 +19,8 @@ const TRANSCODER_VERBOSE = process.env.TRANSCODER_VERBOSE || "0";
 // both
 const TRANSCODE_OPERATING_MODE = process.env.TRANSCODE_OPERATING_MODE || "both";
 const TRANSCODE_EAE_LOCALLY = process.env.TRANSCODE_EAE_LOCALLY || false;
+const TRANSCODE_PREVIEWS_LOCALLY =
+	process.env.TRANSCODE_PREVIEWS_LOCALLY || "true";
 const FORCE_HTTPS = process.env.FORCE_HTTPS || "0";
 
 // validations
@@ -57,6 +59,12 @@ if (TRANSCODE_OPERATING_MODE == "local") {
 	transcodeLocally(process.cwd(), process.argv.slice(2), process.env);
 } else if (process.cwd().indexOf("PlexCreditsDetection") > 0) {
 	console.log("PlexCreditsDetection so forcing local transcode");
+	transcodeLocally(process.cwd(), process.argv.slice(2), process.env);
+} else if (
+	TRANSCODE_PREVIEWS_LOCALLY == "true" &&
+	isPreviewTranscode(process.cwd(), process.argv.slice(2))
+) {
+	console.log("Preview generation detected: forcing local transcode");
 	transcodeLocally(process.cwd(), process.argv.slice(2), process.env);
 } else {
 	function setValueOf(arr, key, newValue) {
@@ -138,6 +146,16 @@ if (TRANSCODE_OPERATING_MODE == "local") {
 			}
 		}
 	);
+}
+
+function isPreviewTranscode(cwd, args) {
+	let previewCwd =
+		cwd.includes("/Media/localhost/") && /\/Indexes(?:\/|$)/.test(cwd);
+	let previewArgs = args.some(
+		(arg) => arg.includes("/Indexes/") || arg.includes("img-%06d.jpg")
+	);
+
+	return previewCwd || previewArgs;
 }
 
 function transcodeLocally(cwd, args, env) {


### PR DESCRIPTION
Force Plex video preview and chapter thumbnail generation to run locally on the PMS instead of sending these jobs to remote workers.

On my setup, Plex preview and chapter thumbnail jobs are dispatched to remote workers, but the workers are unable to process these specific transcoding jobs successfully. Each attempt fails and generates additional error logs, making it difficult to distinguish these expected failures from actual transcoding problems.

## Changes

- Detect Plex preview and chapter thumbnail jobs from their working directory and command-line arguments.
- Force matching jobs to use the local transcoder.
- Add the `TRANSCODE_PREVIEWS_LOCALLY` environment variable.
- Enable local preview transcoding by default.
- Expose the setting through the Helm chart configuration.
- Document the new option.
- Keep regular media transcoding and worker routing unchanged.